### PR TITLE
fix: correct arrays on nextcloud11 & php 7.1

### DIFF
--- a/3rdparty/getid3/module.audio.mp3.php
+++ b/3rdparty/getid3/module.audio.mp3.php
@@ -923,6 +923,7 @@ class getid3_mp3 extends getid3_handler
 				//		$info['warning'][] = 'Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)';
 				//	}
 				} else {
+                                        if (! is_array($info['warning'])) $info['warning'] = array();
 					$info['warning'][] = 'Too much data in file: expecting '.$ExpectedNumberOfAudioBytes.' bytes of audio data, found '.($info['avdataend'] - $info['avdataoffset']).' ('.(($info['avdataend'] - $info['avdataoffset']) - $ExpectedNumberOfAudioBytes).' bytes too many)';
 				}
 			}

--- a/controller/categorycontroller.php
+++ b/controller/categorycontroller.php
@@ -61,7 +61,7 @@ class CategoryController extends Controller {
 		$playlists= $this->getCategoryforUser($category);
 	
 		if(is_array($playlists)){
-			$aPlayLists='';
+			$aPlayLists= array();
 			foreach($playlists as $playinfo){
 				$aPlayLists[]=['info' => $playinfo, 'songids' => $this->getSongIdsForCategory($category,$playinfo['id'])];
 			}
@@ -127,7 +127,7 @@ class CategoryController extends Controller {
 			
 		$stmt =$this->db->prepareQuery($SQL);
 		$result = $stmt->execute(array($this->userId));
-		$aPlaylists='';
+		$aPlaylists=array();
 		while( $row = $result->fetchRow()) {
 			$bg = $this->genColorCodeFromText(trim($row['name']),40,8);
 			$row['backgroundColor']=$bg;
@@ -135,10 +135,10 @@ class CategoryController extends Controller {
 			$aPlaylists[]=$row;
 		}
 		
-		if(is_array($aPlaylists)){
-			return $aPlaylists;
-		}else{
+		if(empty($aPlaylists)){
 			return false;
+		}else{
+			return  $aPlaylists;
 		}
 	}
 	

--- a/controller/musiccontroller.php
+++ b/controller/musiccontroller.php
@@ -253,7 +253,7 @@ class MusicController extends Controller {
 			
 		$stmt = $this->db->prepareQuery($SQL);
 		$result = $stmt->execute(array($this->userId));
-		$aSongs='';
+		$aSongs=array();
 		
 		while( $row = $result->fetchRow()) {
 			$file_not_found = false;
@@ -275,10 +275,10 @@ class MusicController extends Controller {
 				$this->deleteFromDB($row['id'],$row['album_id'],$row['artist_id'],$row['file_id']);
 			}	
 		}
-		if(is_array($aSongs)){
-			return $aSongs;
-		}else{
+		if(empty($aSongs)){
 			return false;
+		}else{
+			return $aSongs;
 		}
 	}
 


### PR DESCRIPTION
Hi, these are a bunch of fixes that prevented my wife to create a brand new library ( fresh install ) from her disk files. All the bugs are in reference to php expecting an array() and instead getting a string.

```
ownCloud[2260]: {index} Exception: {"Exception":"Error","Message":"Cannot use string offset as an array","Code":0,"Trace":"
#0 \/var\/www\/owncloud\/apps\/audioplayer\/controller\/musiccontroller.php(160): OCA\\audioplayer\\Controller\\MusicController->loadSongs()
#1 [internal function]: OCA\\audioplayer\\Controller\\MusicController->getMusic()
#2 \/var\/www\/owncloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php(160): call_user_func_array(Array, Array)
#3 \/var\/www\/owncloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php(90): OC\\AppFramework\\Http\\Dispatcher->executeController(Object(OCA\\audioplayer\\Controller\\MusicController), 'getMusic')
#4 \/var\/www\/owncloud\/lib\/private\/AppFramework\/App.php(114): OC\\AppFramework\\Http\\Dispatcher->dispatch(Object(OCA\\audioplayer\\Controller\\MusicController), 'getMusic')
#5 \/var\/www\/owncloud\/lib\/private\/AppFramework\/Routing\/RouteActionHandler.php(47): OC\\AppFramework\\App::main('OCA\\\\audioplayer...', 'getMusic', Object(OC\\AppFramework\\DependencyInjection\\DIContainer), Array)
#6 [internal function]: OC\\AppFramework\\Routing\\RouteActionHandler->__invoke(Array)
#7 \/var\/www\/owncloud\/lib\/private\/Route\/Router.php(299): call_user_func(Object(OC\\AppFramework\\Routing\\RouteActionHandler), Array)
#8 \/var\/www\/owncloud\/lib\/base.php(1010): OC\\Route\\Router->match('\/apps\/audioplay...')
#9 \/var\/www\/owncloud\/index.php(40): OC::handleRequest()
#10 {main}","File":"\/var\/www\/owncloud\/apps\/audioplayer\/controller\/musiccontroller.php","Line":273}
```