### PR TITLE
fix: Correct ORDER BY syntax for PostgreSQL db

### DIFF
--- a/controller/categorycontroller.php
+++ b/controller/categorycontroller.php
@@ -91,7 +91,7 @@ class CategoryController extends Controller {
 						JOIN `*PREFIX*audioplayer_artists` AA
 						on AA.`id` = AT.`artist_id`
 			 			WHERE  AT.`user_id` = ?
-			 			ORDER BY LOWER(AA.`name`) ASC
+			 			ORDER BY AA.`name` ASC
 			 			";
 		} elseif ($category === 'Genre') {
 			$SQL="SELECT  `id`,`name` FROM `*PREFIX*audioplayer_genre`

--- a/controller/categorycontroller.php
+++ b/controller/categorycontroller.php
@@ -121,7 +121,7 @@ class CategoryController extends Controller {
 						JOIN `*PREFIX*filecache` FC
 						on FC.`fileid` = AT.`folder_id`
 			 			WHERE  AT.`user_id` = ?
-			 			ORDER BY LOWER(FC.`name`) ASC
+			 			ORDER BY FC.`name` ASC
 			 			";
 		}	
 			


### PR DESCRIPTION
Prevent error 'for SELECT DISTINCT, ORDER BY expressions must appear in select list' on postgresql