### PR TITLE
Hotfix/search query

### DIFF
--- a/controller/musiccontroller.php
+++ b/controller/musiccontroller.php
@@ -289,7 +289,7 @@ class MusicController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public  function searchProperties($searchquery){
-		$SQL="SELECT  `id`,`name` FROM `*PREFIX*audioplayer_albums` WHERE (LOWER(`name`) LIKE LOWER(?) OR `year` LIKE ?) AND `user_id` = ?";
+		$SQL="SELECT  `id`,`name` FROM `*PREFIX*audioplayer_albums` WHERE (LOWER(`name`) LIKE LOWER(?) OR `year`" . ($this->getDbType() == 'pgsql' ? "::varchar" : "") . " LIKE ?) AND `user_id` = ?";
 		$stmt = $this->db->prepareQuery($SQL);
 		$result = $stmt->execute(array('%'.addslashes($searchquery).'%', '%'.addslashes($searchquery).'%', $this->userId));
 		$aAlbum ='';

--- a/controller/musiccontroller.php
+++ b/controller/musiccontroller.php
@@ -30,6 +30,7 @@ use \OCP\IRequest;
 use \OCP\IL10N;
 use \OCP\IDb;
 use OCP\Share\IManager;
+use \OCP\IConfig;
 
 /**
  * Controller class for main page.
@@ -49,13 +50,15 @@ class MusicController extends Controller {
 			$userId, 
 			IL10N $l10n, 
 			IDb $db,
-			IManager $shareManager
+			IManager $shareManager,
+			IConfig $config
 		) {
 		parent::__construct($appName, $request);
 		$this->userId = $userId;
 		$this->l10n = $l10n;
 		$this->db = $db;
 		$this->shareManager = $shareManager;
+		$this->config = $config;
 	}
 	/**
 	*@PublicPage
@@ -418,5 +421,11 @@ class MusicController extends Controller {
 		return $data;
 	}
 
-		
+	/*
+	 * Get the type of database backend used by cloud instance
+	 * @return string the database type
+	 */
+	private function getDbType() {
+		return $this->config->getSystemValue('dbtype');
+	}
 }


### PR DESCRIPTION
I found an error when using this application on a postgresql database, the searchProperties function try to compare a string and an integer. It seems that postgresql don't like this.
As a result I propose you to consider adapt your SQL queries to specifics databases requirements.
I 've added a getter to read the database type from (next|own)cloud configuration and I've fix the first bug i've encountered.

As an information this answers to the following error message

An exception occurred while executing 'SELECT  "id","name" FROM "oc_audioplayer_albums" WHERE (LOWER "name") LIKE LOWER(?) OR "year" LIKE ?) AND "user_id" = ?' 
with params ["%exemple of search query%", "%exemple of search query%", "1"]
SQLSTATE[42883]: Undefined function: 7
ERROR:  operator does not exist: integer ~~ unknown
LINE 1: ...ms" WHERE (LOWER("name") LIKE LOWER($1) OR "year" LIKE $2) A...
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.