### PR TITLE
Scanner performance due to direct read

### DIFF
--- a/3rdparty/getid3/getid3.php
+++ b/3rdparty/getid3/getid3.php
@@ -254,7 +254,7 @@ class getID3
 	}
 
 
-	public function openfile($filename, $filesize=null) {
+	public function openfile($filename, $fp=null, $filesize=null) {
 		try {
 			if (!empty($this->startup_error)) {
 				throw new getid3_exception($this->startup_error);
@@ -281,7 +281,9 @@ class getID3
 
 			// open local file
 			//if (is_readable($filename) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) { // see http://www.getid3.org/phpBB3/viewtopic.php?t=1720
-			if ((is_readable($filename) || file_exists($filename)) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) {
+			if ($fp != null && (get_resource_type($fp) == 'file' || get_resource_type($fp) == 'stream')) {
+				$this->fp = $fp;
+			} else if ((is_readable($filename) || file_exists($filename)) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) {
 				// great
 			} else {
 				$errormessagelist = array();
@@ -354,9 +356,9 @@ class getID3
 	}
 
 	// public: analyze file
-	public function analyze($filename, $filesize=null, $original_filename='') {
+	public function analyze($filename, $fp=null, $filesize=null, $original_filename='') {
 		try {
-			if (!$this->openfile($filename, $filesize)) {
+			if (!$this->openfile($filename, $fp, $filesize)) {
 				return $this->info;
 			}
 


### PR DESCRIPTION
The scanner was changed from working with temp-files (for external storage) to working with streams via the \OCP\Files\File's fopen method

Solution proposal came from
https://github.com/owncloud/music/commit/330fc142a27d441808cdc370202718928407a2f4#diff-23d59814ca3a3d2704637f6f0cea2a13