### PR TITLE
Scanner truncates long multiple title properly

### DIFF
--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -1026,7 +1026,7 @@ class ScannerController extends Controller {
 	 * @return string
 	 */
 	private function truncate($string, $length, $dots = "...") {
-    	return (strlen($string) > $length) ? substr($string, 0, $length - strlen($dots)) . $dots : $string;
+    	return (strlen($string) > $length) ? mb_strcut($string, 0, $length - strlen($dots)) . $dots : $string;
 	}
 
 	/**


### PR DESCRIPTION
On scanner, truncate($string, $length, $dots) function just truncated the bytes after `$length - strlen($dots)` bytes.

This sometimes splits multiple bytes character into corrupt UTF-8 string. This leads to SQL error and stop of scanning.

Instead, this should be cut off by mb_strcut, which limits number of bytes but not corrupts UTF-8 string.

For example, `mb_strcut("にゃー", 0, 4)` gets "に", which is first 3 bytes and is a valid UTF-8 string. On the other hand, `substr("にゃー", 0, 4)` puts the first bytes of "ゃ" after "に", which leads to invalid UTF-8 string.

Uploading and scanning mp3 file whose title is `にゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーんにゃーん` , whose first 253 bytes is corrupt UTF-8 string, reproduces the error.