### PR TITLE
Fixed issue with ID3 properties encoding

### DIFF
--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -524,7 +524,7 @@ class ScannerController extends Controller {
 				}
 
 				$album = (string) $this->l10n->t('Unknown');
-				if (isset($ThisFileInfo['comments']['album'][0]) and rawurlencode($ThisFileInfo['comments']['album'][0]) !== '%FF%FE') {
+				if (isset($ThisFileInfo['comments']['album'][0]) and rawurlencode($ThisFileInfo['comments']['album'][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments']['album'][0]) !== FALSE) {
 					$album = $ThisFileInfo['comments']['album'][0];
 				}
 
@@ -538,14 +538,14 @@ class ScannerController extends Controller {
 				$keys = ['year', 'creation_date', 'date'];
 				$c = count($keys);
 				for ($i = 0; $i < $c; $i++) {
-					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE') {
+					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments'][$keys[$i]][0]) !== FALSE) {
 						$year = $ThisFileInfo['comments'][$keys[$i]][0];
 						break;
 					}
 				}
 								
 				$artist = (string) $this->l10n->t('Unknown');
-				if (isset($ThisFileInfo['comments']['artist'][0]) and rawurlencode($ThisFileInfo['comments']['artist'][0]) !== '%FF%FE') {
+				if (isset($ThisFileInfo['comments']['artist'][0]) and rawurlencode($ThisFileInfo['comments']['artist'][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments']['artist'][0]) !== FALSE) {
 					$artist = $ThisFileInfo['comments']['artist'][0];
 				}
 				$iArtistId = $this->writeArtistToDB($artist);
@@ -559,7 +559,7 @@ class ScannerController extends Controller {
 				$keys = ['band', 'album_artist', 'albumartist', 'album artist'];
 				$c = count($keys);
 				for ($i = 0; $i < $c; $i++) {
-					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE') {
+					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments'][$keys[$i]][0]) !== FALSE) {
 						$album_artist = $ThisFileInfo['comments'][$keys[$i]][0];
 						break;
 					}
@@ -568,7 +568,7 @@ class ScannerController extends Controller {
 				$iAlbumId = $this->writeAlbumToDB($album, (int) $year, $iAlbumArtistId);
 
 				$name = $audio->getName();
-				if (isset($ThisFileInfo['comments']['title'][0]) and rawurlencode($ThisFileInfo['comments']['title'][0]) !== '%FF%FE') {
+				if (isset($ThisFileInfo['comments']['title'][0]) and rawurlencode($ThisFileInfo['comments']['title'][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments']['title'][0]) !== FALSE) {
 					$name = $ThisFileInfo['comments']['title'][0];
 				}
 				
@@ -618,14 +618,14 @@ class ScannerController extends Controller {
 				$keys = ['subtitle', 'version'];
 				$c = count($keys);
 				for ($i = 0; $i < $c; $i++) {
-					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE') {
+					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments'][$keys[$i]][0]) !== FALSE) {
 						$subtitle = $ThisFileInfo['comments'][$keys[$i]][0];
 						break;
 					}
 				}
 
 				$composer = '';
-				if (isset($ThisFileInfo['comments']['composer'][0]) and rawurlencode($ThisFileInfo['comments']['composer'][0]) !== '%FF%FE') {
+				if (isset($ThisFileInfo['comments']['composer'][0]) and rawurlencode($ThisFileInfo['comments']['composer'][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments']['composer'][0]) !== FALSE) {
 					$composer = $ThisFileInfo['comments']['composer'][0];
 				}
 
@@ -636,7 +636,7 @@ class ScannerController extends Controller {
 				$keys = ['part_of_a_set', 'discnumber', 'partofset', 'disc_number'];
 				$c = count($keys);
 				for ($i = 0; $i < $c; $i++) {
-					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE') {
+					if (isset($ThisFileInfo['comments'][$keys[$i]][0]) and rawurlencode($ThisFileInfo['comments'][$keys[$i]][0]) !== '%FF%FE' and mb_detect_encoding($ThisFileInfo['comments'][$keys[$i]][0]) !== FALSE) {
 						$disc = $ThisFileInfo['comments'][$keys[$i]][0];
 						break;
 					}


### PR DESCRIPTION
I have issue with getID3 properties encoding xdebug:

![2017-10-02 22 41 41](https://user-images.githubusercontent.com/2007334/31096920-3c2f705e-a7c6-11e7-9778-f7b5a28566a0.png)

From logs:

![2017-10-02 21 26 08](https://user-images.githubusercontent.com/2007334/31097588-7702f29e-a7c8-11e7-92d4-26c2b7765206.png)

and when error appears - process freeze, because this is fatal error.

![2017-10-02 21 25 44](https://user-images.githubusercontent.com/2007334/31097352-aea45fea-a7c7-11e7-8edf-757687f8ea52.png)

and i fixed it by adding checking if function mb_detect_encoding can recognize encoding or not. So if it return false - set Unknown name or artist, etc
- - -
Server: NC 12.0.3, Apache2.4, PHP 7.1, MySQL 5.7.19, Redis, Memcache, 