### PR TITLE
Use jQuery offset when offsetParent fails

### DIFF
--- a/js/bar-ui.js
+++ b/js/bar-ui.js
@@ -223,10 +223,9 @@
 
                 } else if (o.x) {
 
-                    curleft += o.x;
+                    return $(o).offset().left;
 
                 }
-
                 return curleft;
 
             }
@@ -248,7 +247,7 @@
 
                 } else if (o.y) {
 
-                    curtop += o.y;
+                    return $(o).offset().top;
 
                 }
 


### PR DESCRIPTION
Since offsetParent will return null on fixed elements it should use a proper calculation for those cases. 

Fixes #111 

Please have a look @Rello I could not find any documentation for the repo on how to build the minified versions, so for now this is just fixed in the regular js file.