### PR TITLE
Use navigationShown instead of navigation as array key

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -65,7 +65,7 @@ class PageController extends Controller {
 			'uploadMaxHumanFilesize' => \OCP\Util::humanFileSize($maxUploadFilesize),
 			'cyrillic' => $this->configManager->getUserValue($this->userId, $this->appName, 'cyrillic'),
 			'path' => $this->configManager->getUserValue($this->userId, $this->appName, 'path'),
-			'navigation' => $this->configManager->getUserValue($this->userId, $this->appName, 'navigation'),
+			'navigationShown' => $this->configManager->getUserValue($this->userId, $this->appName, 'navigation'),
             'volume' => $this->configManager->getUserValue($this->userId, $this->appName, 'volume') ?: '100',
 			'notification' => $this->getNotification(),
             'audioplayer_editor' => 'false',

--- a/templates/index.php
+++ b/templates/index.php
@@ -34,7 +34,7 @@ if ($_['audioplayer_editor'] === 'true') {
     <input type="hidden" id="audioplayer_volume" value="<?php p($_['volume']); ?>">
     <input type="hidden" id="audioplayer_editor" value="<?php p($_['audioplayer_editor']); ?>">
 
-<div id="app-navigation" <?php if ($_['navigation'] === 'false') echo 'class="ap_hidden"'; ?>>
+<div id="app-navigation" <?php if ($_['navigationShown'] === 'false') echo 'class="ap_hidden"'; ?>>
 
 	<?php print_unescaped($this->inc('part.navigation')); ?>
 	


### PR DESCRIPTION
`navigation` is used by the server template layout, see https://github.com/nextcloud/server/blob/88db07d28ee4d7dac5544a88e2571fe3b5ffaa28/core/templates/layout.user.php#L49

This fixes the app navigation missing in the audioplayer app.

Signed-off-by: Julius Härtl <jus@bitgrid.net>