### PR TITLE
Fix album artist category

### DIFF
--- a/lib/Controller/CategoryController.php
+++ b/lib/Controller/CategoryController.php
@@ -159,12 +159,12 @@ class CategoryController extends Controller
 			 			ORDER BY LOWER(`AB`.`name`) ASC
 			 			";
         } elseif ($category === 'Album Artist') {
-            $SQL = "SELECT  DISTINCT(AB.`artist_id`) AS `id`, AA.`name`, LOWER(AA.`name`) AS `lower` 
+            $SQL = "SELECT  DISTINCT(`AB`.`artist_id`) AS `id`, `AA`.`name`, LOWER(`AA`.`name`) AS `lower` 
 						FROM `*PREFIX*audioplayer_albums` `AB`
-						JOIN `*PREFIX*audioplayer_artists` AA
-						ON AB.`artist_id` = AA.`id`
-			 			WHERE  AB.`user_id` = ?
-			 			ORDER BY LOWER(AA.`name`) ASC
+						JOIN `*PREFIX*audioplayer_artists` `AA`
+						ON `AB`.`artist_id` = `AA`.`id`
+			 			WHERE  `AB`.`user_id` = ?
+			 			ORDER BY LOWER(`AA`.`name`) ASC
 			 			";
 
         }


### PR DESCRIPTION
Was broken at least on NC13 and postgres

Error was:
```
Doctrine\DBAL\Exception\TableNotFoundException: An exception occurred while executing 'SELECT DISTINCT(AB."artist_id") AS "id", AA."name", LOWER(AA."name") AS "lower" FROM "oc_audioplayer_albums" "AB" JOIN "oc_audioplayer_artists" AA ON AB."artist_id" = AA."id" WHERE AB."user_id" = ? ORDER BY LOWER(AA."name") ASC ' with params ["username"]: SQLSTATE[42P01]: Undefined table: 7 ERROR: missing FROM-clause entry for table "ab" LINE 4: ON AB."artist_id" = AA."id"
```

I did not test other setups.