### PR TITLE
Update owncloud version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ See [README](https://github.com/rello/audioplayer/blob/master/README.md) file fo
 	<dependencies>
         <php min-version="7.0" max-version="7.3"/>
 		<nextcloud min-version="14" max-version="15"/>
-		<owncloud min-version="9.1" max-version="10.1"/>
+		<owncloud min-version="9.1" max-version="10"/>
 	</dependencies>
 	<types>
    		<filesystem/>


### PR DESCRIPTION
> App developers should re-release their apps after setting the “max-version” field to “10” instead of “10.0” in “appinfo/info.xml”, and increase the app’s version as well
to make sure ownCloud picks up the change. This is required because else ownCloud 10.1 will think that the apps are not compatible any more and will refuse to update or enable them.

https://central.owncloud.org/t/owncloud-core-switching-to-semver-apps-need-re-release/17054