### PR TITLE
Fix favourite star in sidebar

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -41,8 +41,9 @@ Audios.prototype.showSidebar = function (evt) {
         $('#sidebarTitle').html(decodeURIComponent(trackData.attr('data-path')));
         $('#sidebarMime').html(trackData.attr('data-mimetype'));
 
-        $('#sidebarFavorite').attr({'data-trackid': trackid})
-            .on('click', $this.favoriteUpdate.bind($this));
+        var starIcon = $('#sidebarFavorite').attr({'data-trackid': trackid});
+        starIcon.off();
+        starIcon.on('click', $this.favoriteUpdate.bind($this));
 
         if ($appsidebar.data('trackid') === '') {
             $(".tabHeaders").empty();


### PR DESCRIPTION
OK, so my experience with JS is limited, with jQuery even more so and I did not delve too deep into the code but what I think is happening is that the sidebar is not constructed every time but exists independently of whether it is shown. And every time the sidebar was "unhidden" it registered a new event listener on the same element and continued to stack.
Solved by clearing all listeners from said element before registering a new one. It still seems a bit workaround-ish to me and proper fix should probably register the event listener only once somewhere and subsequently only update the trackid.
