### PR TITLE
Specify code requirements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,48 @@
+module.exports = {
+    'env': {
+        'browser': true,
+        'es6': true,
+        'jquery': true
+    },
+    'extends': 'eslint:recommended',
+    'globals': {
+        'OC': 'readonly',
+        'OCA': 'readonly',
+        't': 'readonly'
+    },
+    'parserOptions': {
+        'ecmaVersion': 6,
+        'sourceType': 'module'
+    },
+    'rules': {
+        'brace-style': [
+            'error',
+            '1tbs',
+            { 'allowSingleLine': true }
+        ],
+        'curly': [
+            'error',
+            'all'
+        ],
+        'indent': [
+            'error',
+            4
+        ],
+        'linebreak-style': [
+            'error',
+            'unix'
+        ],
+        'no-console': [
+            'error',
+            { allow: [ 'warn', 'error' ] }
+        ],
+        'quotes': [
+            'error',
+            'single'
+        ],
+        'semi': [
+            'error',
+            'always'
+        ],
+    }
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to Audio Player
+
+## JS
+In addition to the eslint rules any submitted code must be compatible with iOS 9.3.5 (Safari 9).
+Said browser has full ES5 support and limited ES6 support. Most notably:
+- ES6 classes are [allowed](https://caniuse.com/#feat=es6-class)
+- Template literals are [allowed](https://caniuse.com/#feat=template-literals)
+- `let` keyword is [disallowed](https://caniuse.com/#feat=let)
+- `const` keyword is [disallowed](https://caniuse.com/#feat=const)
+- ES6 modules (`import`, `export`) are [disallowed](https://caniuse.com/#feat=es6-module)
+- arrow functions (`(args) => {body}`) are [disallowed](https://caniuse.com/#feat=arrow-functions)


### PR DESCRIPTION
This is an initial version of what I would like to become AP's lint config.  Most rules are just based on current state of the code (or most of it) while others on [NC recommendations](https://docs.nextcloud.com/server/stable/developer_manual/general/codingguidelines.html#javascript) and my personal opinions.
I also included predefined globals based on their use in the code, but I could not find any mention of them in NC docs. Could you point me in the right direction?
I also picked ecmaVersion 6 as target version which is according to [caniuse](https://caniuse.com/#feat=es6) well supported (95%+ of browsers out there) and brings nice features like modules, arrow functions or proper classes.
Thoughts, comments?