### PR TITLE
Fix hotkey clashing

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,45 +51,48 @@ OCA.Audioplayer.Core = {
 
     initKeyListener: function () {
         document.body.addEventListener('keydown', function (e) {
-            if (OCA.Audioplayer.Core.Player !== null && $('#activePlaylist li').length > 0) {
-
-                if (e.target) {
-                    var nodeName = e.target.nodeName.toUpperCase();
-                    //don't activate shortcuts when the user is in an input, textarea or select element
-                    if (nodeName === 'INPUT' || nodeName === 'TEXTAREA' || nodeName === 'SELECT') {
-                        return;
-                    }
+            if (e.target) {
+                var nodeName = e.target.nodeName.toUpperCase();
+                //don't activate shortcuts when the user is in an input, textarea or select element
+                if (nodeName === 'INPUT' || nodeName === 'TEXTAREA' || nodeName === 'SELECT') {
+                    return;
                 }
+            }
 
+            if (OCA.Audioplayer.Core.Player && $('#activePlaylist li').length > 0) {
                 var currentVolume;
                 var newVolume;
-                if (e.key === ' ') {//Space pause/play
+                switch (e.key) {
+                case ' ':
                     if ($('.sm2-bar-ui').hasClass('playing')) {
-                        OCA.Audioplayer.Core.Player.actions.stop();
+                        OCA.Audioplayer.Core.Player.actions.pause();
                     } else {
-                        OCA.Audioplayer.Core.Player.actions.play();
+                        OCA.Audioplayer.Core.Player.actions.resume();
                     }
                     e.preventDefault();
-                } else if (e.key === 'ArrowRight') {// right
+                    break;
+                case 'ArrowRight':
                     OCA.Audioplayer.Core.Player.actions.next();
-                } else if (e.key === 'ArrowLeft') {//left
+                    break;
+                case 'ArrowLeft':
                     OCA.Audioplayer.Core.Player.actions.prev();
-                } else if (e.key === 'ArrowUp') {//up sound up
+                    break;
+                case 'ArrowUp':
                     currentVolume = OCA.Audioplayer.Core.Player.actions.getVolume();
                     if (currentVolume < 100) {
-                        newVolume = currentVolume + 10;
-                        if (newVolume >= 100) { newVolume = 100; }
+                        newVolume = Math.min(currentVolume + 10, 100);
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
                     e.preventDefault();
-                } else if (e.key === 'ArrowDown') {//down sound down
+                    break;
+                case 'ArrowDown':
                     currentVolume = OCA.Audioplayer.Core.Player.actions.getVolume();
                     if (currentVolume > 0) {
-                        newVolume = currentVolume - 10;
-                        if (newVolume <= 0) { newVolume = 0; }
+                        newVolume = Math.max(currentVolume - 10, 0);
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
                     e.preventDefault();
+                    break;
                 }
             }
         });

--- a/js/app.js
+++ b/js/app.js
@@ -63,13 +63,13 @@ OCA.Audioplayer.Core = {
 
                 var currentVolume;
                 var newVolume;
-                if (e.key === 'Space') {//Space pause/play
+                if (e.key === ' ') {//Space pause/play
                     if ($('.sm2-bar-ui').hasClass('playing')) {
                         OCA.Audioplayer.Core.Player.actions.stop();
                     } else {
                         OCA.Audioplayer.Core.Player.actions.play();
                     }
-                } else if (e.key === 39) {// right
+                } else if (e.key === 'ArrowRight') {// right
                     OCA.Audioplayer.Core.Player.actions.next();
                 } else if (e.key === 'ArrowLeft') {//left
                     OCA.Audioplayer.Core.Player.actions.prev();

--- a/js/app.js
+++ b/js/app.js
@@ -69,6 +69,7 @@ OCA.Audioplayer.Core = {
                     } else {
                         OCA.Audioplayer.Core.Player.actions.play();
                     }
+                    e.preventDefault();
                 } else if (e.key === 'ArrowRight') {// right
                     OCA.Audioplayer.Core.Player.actions.next();
                 } else if (e.key === 'ArrowLeft') {//left
@@ -80,6 +81,7 @@ OCA.Audioplayer.Core = {
                         if (newVolume >= 100) newVolume = 100;
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
+                    e.preventDefault();
                 } else if (e.key === 'ArrowDown') {//down sound down
                     currentVolume = OCA.Audioplayer.Core.Player.actions.getVolume();
                     if (currentVolume > 0) {
@@ -87,6 +89,7 @@ OCA.Audioplayer.Core = {
                         if (newVolume <= 0) newVolume = 0;
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
+                    e.preventDefault();
                 }
             }
         })

--- a/js/app.js
+++ b/js/app.js
@@ -78,7 +78,7 @@ OCA.Audioplayer.Core = {
                     currentVolume = OCA.Audioplayer.Core.Player.actions.getVolume();
                     if (currentVolume < 100) {
                         newVolume = currentVolume + 10;
-                        if (newVolume >= 100) newVolume = 100;
+                        if (newVolume >= 100) { newVolume = 100; }
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
                     e.preventDefault();
@@ -86,13 +86,13 @@ OCA.Audioplayer.Core = {
                     currentVolume = OCA.Audioplayer.Core.Player.actions.getVolume();
                     if (currentVolume > 0) {
                         newVolume = currentVolume - 10;
-                        if (newVolume <= 0) newVolume = 0;
+                        if (newVolume <= 0) { newVolume = 0; }
                         OCA.Audioplayer.Core.Player.actions.setVolume(newVolume);
                     }
                     e.preventDefault();
                 }
             }
-        })
+        });
     },
 
     processSearchResult: function () {


### PR DESCRIPTION
Previous implementation continued propagating keys to browser.
Additionally previous commits to master broke hotkeys for me completely (Firefox, Brave), so that's also fixed.
Last two commits should improve readability and correctness.