### PR TITLE
trackClickHandler optimizations

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -612,15 +612,15 @@ OCA.Audioplayer.UI = {
     },
 
     trackClickHandler: function (callback) {
-        var albumWrapper = $('.albumwrapper');
+        var albumWrapper = document.getElementById('individual-playlist');
         var getcoverUrl = OC.generateUrl('apps/audioplayer/getcover/');
         var category = OCA.Audioplayer.UI.PlaylistContainer.data('playlist').split('-');
 
         var canPlayMimeType = OCA.Audioplayer.Core.canPlayMimeType;
-        var playlist = albumWrapper.find('li');
+        var playlist = albumWrapper.getElementsByTagName('li');
 
-        playlist.each(function (index, elm) {
-            var element = $(elm);
+        for (var track of playlist) {
+            var element = $(track);
 
             if (!(category[0] === 'Playlist' && category[1].toString()[0] !== 'X' && category[1] !== '')) {
                 element.draggable({
@@ -637,7 +637,7 @@ OCA.Audioplayer.UI = {
             element.on('click', function() {
                 OCA.Audioplayer.UI.onTitleClick(getcoverUrl, canPlayMimeType, playlist, element);
             });
-        });
+        }
         // the callback is used for the the init function to get feedback when all title rows are ready
         if (typeof callback === 'function') {
             callback();
@@ -667,7 +667,7 @@ OCA.Audioplayer.UI = {
             // the visible playlist has to be copied to the player queue
             // this disconnects the free navigation in AP while continuing to play a playlist
             if (OCA.Audioplayer.UI.PlaylistContainer.data('playlist') !== OCA.Audioplayer.UI.ActivePlaylist.data('playlist')) {
-                var ClonePlaylist = playlist.clone();
+                var ClonePlaylist = $(playlist).clone();
                 OCA.Audioplayer.UI.ActivePlaylist.html('');
                 OCA.Audioplayer.UI.ActivePlaylist.append(ClonePlaylist);
                 OCA.Audioplayer.UI.ActivePlaylist.find('span').remove();

--- a/js/app.js
+++ b/js/app.js
@@ -633,11 +633,10 @@ OCA.Audioplayer.UI = {
                     }
                 });
             }
-
-            element.on('click', function() {
-                OCA.Audioplayer.UI.onTitleClick(getcoverUrl, canPlayMimeType, playlist, element);
-            });
         }
+        albumWrapper.addEventListener('click', function(event) {
+            OCA.Audioplayer.UI.onTitleClick(getcoverUrl, canPlayMimeType, playlist, event.target);
+        });
         // the callback is used for the the init function to get feedback when all title rows are ready
         if (typeof callback === 'function') {
             callback();
@@ -645,7 +644,7 @@ OCA.Audioplayer.UI = {
     },
 
     onTitleClick: function (coverUrl, canPlayMimeType, playlist, element) {
-        var activeLi = element.closest('li');
+        var activeLi = $(element).closest('li');
         // if enabled, play sonos and skip the rest of the processing
         if ($('#audioplayer_sonos').val() === 'checked') {
             var liIndex = element.parents('li').index();

--- a/js/app.js
+++ b/js/app.js
@@ -619,11 +619,9 @@ OCA.Audioplayer.UI = {
         var canPlayMimeType = OCA.Audioplayer.Core.canPlayMimeType;
         var playlist = albumWrapper.getElementsByTagName('li');
 
-        for (var track of playlist) {
-            var element = $(track);
-
-            if (!(category[0] === 'Playlist' && category[1].toString()[0] !== 'X' && category[1] !== '')) {
-                element.draggable({
+        if (!(category[0] === 'Playlist' && category[1].toString()[0] !== 'X' && category[1] !== '')) {
+            for (var track of playlist) {
+                $(track).draggable({
                     appendTo: 'body',
                     helper: OCA.Audioplayer.Playlists.dragElement,
                     cursor: 'move',


### PR DESCRIPTION
Called 100 times in a loop for 6.7k tracks in a playlist.
```
Firefox
master
default: 6787ms - timer ended

replace .each
default: 5503ms - timer ended

1 handler
default: 2402ms - timer ended

all
default: 2272ms - timer ended

Brave:
master
default: 8478.673828125ms

all
default: 3807.89013671875ms
```
~Remaining time is still way too high~, but I'll give myself a brief pause from AP. I think remaining seconds are mainly caused by getting the \<li> elements and that could be avoided with a clever idea.
Edit: sorry, I was off by one decimal point. It's 0.06/0.02 second per call. OK :)