### PR TITLE
Prevent screen jump when starring from sidebar

### DIFF
--- a/templates/part.sidebar.php
+++ b/templates/part.sidebar.php
@@ -21,7 +21,7 @@
             <div class="fileName"><h3 id="sidebarTitle"></h3>
             </div>
             <div class="file-details ellipsis">
-                <a href="#" class="action action-favorite favorite permanent">
+                <a href="javascript:void(0)" class="action action-favorite favorite permanent">
                     <span id="sidebarFavorite" class="icon icon-star" title=""></span>
                 </a>
                 <span id="sidebarMime"></span>


### PR DESCRIPTION
QoL addition to QoL fixes (#418). Previous code caused jump to top if starring longer playlists.