### PR TITLE
Scanner adjustments

### DIFF
--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -156,6 +156,7 @@ class ScannerController extends Controller
         if ($this->cyrillic === 'checked') $output->writeln("Cyrillic processing activated", OutputInterface::VERBOSITY_VERBOSE);
         $output->writeln("Start processing of <info>audio files</info>", OutputInterface::VERBOSITY_VERBOSE);
 
+        $commitThreshold = max(200, intdiv(count($audios), 10));
         $this->DBController->beginTransaction();
         try {
             foreach ($audios as &$audio) {
@@ -179,7 +180,7 @@ class ScannerController extends Controller
                 if ($this->timeForUpdate()) {
                     $this->updateProgress($counter, $audio->getPath(), $output);
                 }
-                if ($counter % 200 == 0) {
+                if ($counter % $commitThreshold == 0) {
                     $this->DBController->commit();
                     $output->writeln("Status committed to database", OutputInterface::VERBOSITY_VERBOSE);
                     $this->DBController->beginTransaction();

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -182,6 +182,7 @@ class ScannerController extends Controller
                 if ($counter % 200 == 0) {
                     $this->DBController->commit();
                     $output->writeln("Status committed to database", OutputInterface::VERBOSITY_VERBOSE);
+                    $this->DBController->beginTransaction();
                 }
             }
 

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -158,7 +158,7 @@ class ScannerController extends Controller
 
         $this->DBController->beginTransaction();
         try {
-            foreach ($audios as $audio) {
+            foreach ($audios as &$audio) {
                 if ($this->scanCancelled()) { break; }
 
                 $counter++;
@@ -181,7 +181,7 @@ class ScannerController extends Controller
             }
 
             $output->writeln("Start processing of <info>stream files</info>", OutputInterface::VERBOSITY_VERBOSE);
-            foreach ($streams as $stream) {
+            foreach ($streams as &$stream) {
                 if ($this->scanCancelled()) { break; }
 
                 $counter++;
@@ -474,7 +474,7 @@ class ScannerController extends Controller
         $results = $stmt->fetchAll();
         $resultExisting = array_column($results, 'file_id');
 
-        foreach ($audios as $key => $audio) {
+        foreach ($audios as $key => &$audio) {
             $current_id = $audio->getID();
             if (in_array($current_id, $resultExclude)) {
                 $output->writeln("   " . $current_id . " - " . $audio->getPath() . "  => excluded", OutputInterface::VERBOSITY_VERY_VERBOSE);
@@ -555,7 +555,7 @@ class ScannerController extends Controller
         $results = $stmt->fetchAll();
         $resultExisting = array_column($results, 'file_id');
 
-        foreach ($audios as $key => $audio) {
+        foreach ($audios as $key => &$audio) {
             $current_id = $audio->getID();
             if (in_array($current_id, $resultExclude)) {
                 $output->writeln("   " . $current_id . " - " . $audio->getPath() . "  => excluded", OutputInterface::VERBOSITY_VERY_VERBOSE);

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -109,6 +109,7 @@ class ScannerController extends Controller
      */
     public function scanForAudios($userId = null, $output = null, $scanstop = null)
     {
+        set_time_limit(0);
         if (isset($scanstop)) {
             $this->DBController->setSessionValue('scanner_running', 'stopped', $this->userId);
             $params = ['status' => 'stopped'];


### PR DESCRIPTION
Continued from https://github.com/Rello/audioplayer/commit/7d2a204fb8d48409dfc2a6454c2698756abe5080#comments.

I don't like any solution involving arbitrary magic numbers because there will always be that one person that will need the magic number just a bit different, so I tried to solve most cases in better way.
PHP timeouts should not be an issue now and there was no reason why ID3 exceptions (or pretty much anything non-DB related) should mean throwing work away.
I used the idea with dynamic threshold and made it hopefully OK for people with thousands of tracks as well as people with just 10.
I did not do anything for SMB shares, since I don't have one and have no idea what kind of error that could result in.
Memory handling is a bit improved but the only real solution for huge libraries and low memory limit is processing the audio in smaller batches and I'm not sure it's worth the trouble. I looked into NC's API and found it lacking for anything other than "gimme all of it".
Does it cover most of scanning woes?