### PR TITLE
Fix sorting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -794,15 +794,16 @@ OCA.Audioplayer.UI = {
     },
 
     sortPlaylist: function (evt) {
-        var column = $(evt.target).attr('class').split('-')[1];
-        var order = $(evt.target).data('order');
+        var evtTarget = evt.target;
+        var column = evtTarget.getAttribute('class').split('-')[1];
+        var order = evtTarget.getAttribute('data-order');
         var factor = 1;
 
         if (order === 'descending') {
             factor = -1;
-            $(evt.target).data('order', 'ascending');
+            evtTarget.setAttribute('data-order', 'ascending');
         } else {
-            $(evt.target).data('order', 'descending');
+            evtTarget.setAttribute('data-order', 'descending');
         }
 
         var elems = $('#individual-playlist').children('li').get();
@@ -814,13 +815,9 @@ OCA.Audioplayer.UI = {
         elems.sort(function (a, b) {
             return OCA.Audioplayer.UI.compareTracks(a, b, reg_check, column) * factor;
         });
-        $('#individual-playlist').append(elems);
+        $('#individual-playlist').append(elems.slice(0));
 
         if (OCA.Audioplayer.UI.PlaylistContainer.data('playlist') === OCA.Audioplayer.UI.ActivePlaylist.data('playlist')) {
-            elems = OCA.Audioplayer.UI.ActivePlaylist.children('li').get();
-            elems.sort(function (a, b) {
-                return OCA.Audioplayer.UI.compareTracks(a, b, reg_check, column) * factor;
-            });
             OCA.Audioplayer.UI.ActivePlaylist.append(elems);
         }
 

--- a/js/app.js
+++ b/js/app.js
@@ -794,6 +794,19 @@ OCA.Audioplayer.UI = {
         }
     },
 
+    compareTracks: function (a, b, reg_check, column) {
+        a = $(a).data(column).toString();
+        b = $(b).data(column).toString();
+        if (reg_check) {
+            a = parseInt(a.split('-')[0]) * 100 + parseInt(a.split('-')[1]);
+            b = parseInt(b.split('-')[0]) * 100 + parseInt(b.split('-')[1]);
+        } else {
+            a = a.toLowerCase();
+            b = b.toLowerCase();
+        }
+        return ((a < b) ? 1 : ((a > b) ? -1 : 0));
+    },
+
     sortPlaylist: function (evt) {
         var column = $(evt.target).attr('class').split('-')[1];
         var order = $(evt.target).data('order');
@@ -813,32 +826,14 @@ OCA.Audioplayer.UI = {
 
         var reg_check = $(elems).first().data(column).toString().match(/^\d{1,2}-\d{1,2}$/);
         elems.sort(function (a, b) {
-            a = $(a).data(column).toString();
-            b = $(b).data(column).toString();
-            if (reg_check) {
-                a = parseInt(a.split('-')[0]) * 100 + parseInt(a.split('-')[1]);
-                b = parseInt(b.split('-')[0]) * 100 + parseInt(b.split('-')[1]);
-            } else {
-                a = a.toLowerCase();
-                b = b.toLowerCase();
-            }
-            return ((a < b) ? -1 * factor : ((a > b) ? factor : 0));
+            return OCA.Audioplayer.UI.compareTracks(a, b, reg_check, column) * factor;
         });
         $('#individual-playlist').append(elems);
 
         if (OCA.Audioplayer.UI.PlaylistContainer.data('playlist') === OCA.Audioplayer.UI.ActivePlaylist.data('playlist')) {
             elems = OCA.Audioplayer.UI.ActivePlaylist.children('li').get();
             elems.sort(function (a, b) {
-                a = $(a).data(column).toString();
-                b = $(b).data(column).toString();
-                if (reg_check) {
-                    a = parseInt(a.split('-')[0]) * 100 + parseInt(a.split('-')[1]);
-                    b = parseInt(b.split('-')[0]) * 100 + parseInt(b.split('-')[1]);
-                } else {
-                    a = a.toLowerCase();
-                    b = b.toLowerCase();
-                }
-                return ((a < b) ? -1 * factor : ((a > b) ? factor : 0));
+                return OCA.Audioplayer.UI.compareTracks(a, b, reg_check, column) * factor;
             });
             OCA.Audioplayer.UI.ActivePlaylist.append(elems);
         }

--- a/js/app.js
+++ b/js/app.js
@@ -844,11 +844,14 @@ OCA.Audioplayer.UI = {
         }
 
         if (OCA.Audioplayer.Core.Player) {
-            var k = 0, e = document.querySelector('#activePlaylist li.selected');
-            while (e = e.previousSibling) {
-                ++k;
+            var e = document.querySelector('#activePlaylist li.selected');
+            if (e) {
+                var k = 0;
+                while (e = e.previousSibling) {
+                    ++k;
+                }
+                OCA.Audioplayer.Core.Player.playlistController.data.selectedIndex = k;
             }
-            OCA.Audioplayer.Core.Player.playlistController.data.selectedIndex = k;
         }
     },
 

--- a/js/app.js
+++ b/js/app.js
@@ -485,24 +485,10 @@ OCA.Audioplayer.Category = {
                 document.getElementById('loading').style.display = 'none';
                 if (jsondata.status === 'success') {
                     document.getElementById('sm2-bar-ui').style.display = 'block';
-                    var titleCounter = 0;
                     var itemRows = document.createDocumentFragment();
                     for (var itemData of jsondata.data) {
                         var tempItem = OCA.Audioplayer.UI.buildTrackRow(itemData, covers);
                         itemRows.appendChild(tempItem);
-                        titleCounter++;
-                    }
-
-                    //required for Cover View
-                    // add a blank row in case of uneven records=>avoid a Chrome bug to strangely split the records across columns
-                    if (titleCounter % 2 !== 0) {
-                        var li = document.createElement('li');
-                        li.classList.add('noPlaylist');
-                        var spanNr = document.createElement('span');
-                        spanNr.classList.add('number');
-                        spanNr.innerText = '\u00A0';
-                        li.appendChild(spanNr);
-                        itemRows.appendChild(li);
                     }
 
                     document.querySelector('.albumwrapper').appendChild(itemRows);


### PR DESCRIPTION
The sorting bug made playlists with odd number of tracks unsortable. This has been in since forever. Either sorting didn't really work for years or the error got silently dropped previously due to JS not executing in strict mode. I deleted the workaround because it was from several years back and dropping it didn't break anything for me.

There was another problem with sorting if no track was selected as active but from the outside everything looked fine.
