### PR TITLE
[CSS] split style for webkit and firefox slider

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -840,7 +840,15 @@ input[type=range].volume-slider:focus {
     outline: none;
 }
 
-input[type=range].volume-slider::-webkit-slider-runnable-track, input[type=range].volume-slider::-moz-range-track {
+input[type=range].volume-slider::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 8px;
+    cursor: pointer;
+    background: var(--color-background-dark);
+    border-radius: var(--border-radius);
+}
+
+input[type=range].volume-slider::-moz-range-track {
     width: 100%;
     height: 8px;
     cursor: pointer;
@@ -877,7 +885,12 @@ input[type=range].volume-slider::-ms-track {
     color: transparent;
 }
 
-input[type=range].volume-slider::-ms-fill-lower, input[type=range].volume-slider::-ms-fill-upper {
+input[type=range].volume-slider::-ms-fill-lower {
+    background: #ededed;
+    border-radius: 3px;
+}
+
+input[type=range].volume-slider::-ms-fill-upper {
     background: #ededed;
     border-radius: 3px;
 }
@@ -887,7 +900,7 @@ input[type=range].volume-slider::-ms-thumb {
     height: 14px;
     width: 14px;
     border-radius: 7px;
-    background: #ffffff;
+    background: #fff;
     cursor: pointer;
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -837,7 +837,15 @@ input[type=range].volume-slider:focus {
   outline: none;
 }
 
-input[type=range].volume-slider::-webkit-slider-runnable-track, input[type=range].volume-slider::-moz-range-track {
+input[type=range].volume-slider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 8px;
+  cursor: pointer;
+  background: var(--color-background-dark);
+  border-radius: var(--border-radius);
+}
+
+input[type=range].volume-slider::-moz-range-track {
   width: 100%;
   height: 8px;
   cursor: pointer;
@@ -874,7 +882,12 @@ input[type=range].volume-slider::-ms-track {
   color: transparent;
 }
 
-input[type=range].volume-slider::-ms-fill-lower, input[type=range].volume-slider::-ms-fill-upper {
+input[type=range].volume-slider::-ms-fill-lower {
+  background: #ededed;
+  border-radius: 3px;
+}
+
+input[type=range].volume-slider::-ms-fill-upper {
   background: #ededed;
   border-radius: 3px;
 }
@@ -884,7 +897,7 @@ input[type=range].volume-slider::-ms-thumb {
   height: 14px;
   width: 14px;
   border-radius: 7px;
-  background: #ffffff;
+  background: #fff;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Cosmetic change, due to webkit problem with parsing combined styles with pseudo-elements.