### PR TITLE
Improvement Breeze Dark theme support

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -816,9 +816,8 @@ input[type=range].volume-slider {
   background: var(--color-main-background);
 }
 
-.volume-slider::-webkit-slider-progress,
 .volume-slider::-moz-range-progress {
-    background-color: var(--color-background-hover);
+    background-color: #0082c9;
     padding: 2px;
     border-radius: 5px;
 }
@@ -831,7 +830,7 @@ input[type=range].volume-slider::-webkit-slider-runnable-track {
   width: 100%;
   height: 8px;
   cursor: pointer;
-  background: var(--color-background-dark);
+  background: var(--color-background-darker);
   border-radius: var(--border-radius);
 }
 

--- a/templates/part.audio.php
+++ b/templates/part.audio.php
@@ -54,7 +54,7 @@
                 <div id="progressContainer" style="padding-top: 3px; padding-right: 15px;">
                     <canvas id="progressBar" height="8" style="
                     width: 100%;
-    background-color: var(--color-background-dark);
+    background-color: var(--color-background-darker);
     border-radius: var(--border-radius);
     border: 0 none;
     height: 8px;


### PR DESCRIPTION
1. moz-range-progress not have alternatives in webkit (webkit-slider-progress - not a alternate) this added blue progress in volume slider.
2. Use darker colors in progress bars. (Dark color seen transparently on breeze dark theme)

## Firefox preview:
![image](https://user-images.githubusercontent.com/18057310/160212885-0bdf755f-b55f-4725-beb7-5eb8c40602a7.png)


## Edge (chromium) preview:
(i don't know how realise volume-progress color without js-code in chromium)
![image](https://user-images.githubusercontent.com/18057310/160212968-89b3a548-68ed-42ac-ab98-d2dc17c5f6e6.png)

