### PR TITLE
allow more loudness gradations

### DIFF
--- a/templates/part.audio.php
+++ b/templates/part.audio.php
@@ -68,7 +68,7 @@
         <div class="sm2-inline-element sm2-button-element sm2-volume" data-placement="left"
              title="<?php p($l->t('Volume')); ?>">
             <input id="playerVolume" type="range" class="sm2-button-bd sm2-inline-button volume-slider" min="0" max="1"
-                   step="0.1" value="1">
+                   step="0.02" value="1">
         </div>
 
         <div class="sm2-inline-element sm2-button-element sm2-repeat" style="left: 7px;" data-placement="left"


### PR DESCRIPTION
Hello,
this request is about changing the volume-slider step size. I have two computers where changing the volume from 0 to 10% (step 0.1) has a very strong effect. In fact loudness on 2% is often enough and I need this low volume to be able hearing music in the background and do video conferencing in the foreground. Unfortunately I'm unable to raise the loudness of video conferencing independently from all other sound sources - so 10% for music is to much.

I would be pleased if this change were to be adopted.

In any case, thank you for the work on this project - I like this player very much.

Best regards, Sebastian 