### PR TITLE
Added highlighting Hover/Current playing track.

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -807,8 +807,17 @@ i#scanAudiosFirst {
   opacity: 1;
 }
 
+.albumwrapper li:hover * {
+  cursor: pointer;
+}
+
+.albumwrapper li:hover:not(.isActive) {
+  background: var(--color-border);
+}
+
 .isActive {
   font-weight: bold;
+  background: var(--color-border-dark);
 }
 
 input[type=range].volume-slider {


### PR DESCRIPTION
## Description
It was quite difficult for me to find the current track, especially in the Dark's Brease. Therefore, I made such a backlight of the current track and also complemented the cursor and hover-effect mechanics a little.

## In default theme:
![image](https://user-images.githubusercontent.com/18057310/168441035-4f5267e1-cfae-4bad-b0a7-66f9621cc1ca.png)
![image](https://user-images.githubusercontent.com/18057310/168441097-031c6348-b945-4c3b-8cc4-097650d13c69.png)

## In breeze dark theme
![image](https://user-images.githubusercontent.com/18057310/168441206-5693b395-493c-453a-8554-e08a41498324.png)
![image](https://user-images.githubusercontent.com/18057310/168441251-a060e847-6471-46b9-968e-43bc26f03c96.png)
