### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to the Audio Player project will be documented in this file.
 
+## 3.4.2 - 2025-07-12
+### Fixed
+- PHP 8.4 compatibility for nullable parameters
+
 ## 3.4.1 - 2023-12-11
 ### Fixed
 - IEventSourceFactory NC28 compatibility

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -413,7 +413,7 @@ class ScannerController extends Controller
      * @param string $currentFile
      * @param OutputInterface|null $output
      */
-    private function updateProgress($filesProcessed, $currentFile, OutputInterface $output = null)
+    private function updateProgress($filesProcessed, $currentFile, ?OutputInterface $output = null)
     {
         if (!$this->occJob) {
             $response = [
@@ -468,7 +468,7 @@ class ScannerController extends Controller
      * @throws NotFoundException
      * @throws \OCP\Files\InvalidPathException
      */
-    private function getAudioObjects(OutputInterface $output = null)
+    private function getAudioObjects(?OutputInterface $output = null)
     {
         $audioPath = $this->configManager->getUserValue($this->userId, $this->appName, 'path');
         $userView = $this->rootFolder->getUserFolder($this->userId);
@@ -562,7 +562,7 @@ class ScannerController extends Controller
      * @return array
      * @throws NotFoundException
      */
-    private function getStreamObjects(OutputInterface $output = null)
+    private function getStreamObjects(?OutputInterface $output = null)
     {
         $audios_clean = array();
         $audioPath = $this->configManager->getUserValue($this->userId, $this->appName, 'path');
@@ -627,7 +627,7 @@ class ScannerController extends Controller
      * @param $getID3 object
      * @param OutputInterface $output
      */
-    private function analyze($audio, $getID3, OutputInterface $output = null)
+    private function analyze($audio, $getID3, ?OutputInterface $output = null)
     {
         $this->ID3Tags = array();
         $ThisFileInfo = array();
@@ -735,7 +735,7 @@ class ScannerController extends Controller
      * @param OutputInterface|null $output
      * @return boolean|null
      */
-    private function getAlbumArt($audio, $iAlbumId, $parentId, OutputInterface $output = null)
+    private function getAlbumArt($audio, $iAlbumId, $parentId, ?OutputInterface $output = null)
     {
         if ($parentId === $this->parentIdPrevious) {
             if ($this->folderPicture) {


### PR DESCRIPTION
## Summary
- declare nullable parameters explicitly for PHP 8.4
- document change in changelog

## Testing
- `php -l lib/Controller/ScannerController.php`


------
https://chatgpt.com/codex/tasks/task_e_6872807154f48333a178819437a23049