### PR TITLE
Refactor MusicMapper queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 All notable changes to the Audio Player project will be documented in this file.
 
-## 3.4.1 - 2023-12-11
-### Fixed
-- IEventSourceFactory NC28 compatibility
+## 3.5.0 - in progress
+### Added
+
 ### Changed
 - refactored MusicController into service and mapper
 - migrated MusicMapper to use QueryBuilder
+
+### Fixed
+
+
+## 3.4.1 - 2023-12-11
+### Fixed
+- IEventSourceFactory NC28 compatibility
 
 ## 3.4.0 - 2023-06-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.4.1 - 2023-12-11
 ### Fixed
 - IEventSourceFactory NC28 compatibility
+### Changed
+- refactored MusicController into service and mapper
+- migrated MusicMapper to use QueryBuilder
 
 ## 3.4.0 - 2023-06-17
 ### Added

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,6 +25,7 @@ return [
 	['name' => 'scanner#getImportTpl', 'url' => '/getimporttpl', 'verb' => 'GET'],
 	['name' => 'scanner#scanForAudios', 'url' => '/scanforaudiofiles', 'verb' => 'GET'],
 	['name' => 'scanner#checkNewTracks', 'url' => '/checknewtracks', 'verb' => 'POST'],
+
 	['name' => 'music#getAudioStream', 'url' => '/getaudiostream', 'verb' => 'GET'],
     ['name' => 'music#getPublicAudioStream', 'url' => '/getpublicaudiostream', 'verb' => 'GET'],
     ['name' => 'db#resetMediaLibrary', 'url' => '/resetmedialibrary', 'verb' => 'GET'],

--- a/lib/Controller/MusicController.php
+++ b/lib/Controller/MusicController.php
@@ -16,46 +16,19 @@ namespace OCA\audioplayer\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
-use OCP\IL10N;
-use OCP\IDBConnection;
-use OCP\Share\IManager;
-use OCP\Files\IRootFolder;
-use Psr\Log\LoggerInterface;
+use OCA\audioplayer\Service\MusicService;
 
 /**
  * Controller class for main page.
  */
 class MusicController extends Controller
 {
+    private MusicService $service;
 
-    private $userId;
-    private $l10n;
-    private $db;
-    private $shareManager;
-    private $logger;
-    private $DBController;
-    private $rootFolder;
-
-    public function __construct(
-        $appName,
-        IRequest $request,
-        $userId,
-        IL10N $l10n,
-        IDBConnection $db,
-        IManager $shareManager,
-        LoggerInterface $logger,
-        DbController $DBController,
-        IRootFolder $rootFolder
-    )
+    public function __construct(string $appName, IRequest $request, MusicService $service)
     {
         parent::__construct($appName, $request);
-        $this->userId = $userId;
-        $this->l10n = $l10n;
-        $this->db = $db;
-        $this->shareManager = $shareManager;
-        $this->logger = $logger;
-        $this->DBController = $DBController;
-        $this->rootFolder = $rootFolder;
+        $this->service = $service;
     }
 
     /**
@@ -68,47 +41,18 @@ class MusicController extends Controller
      */
     public function getPublicAudioInfo($token)
     {
-        if (!empty($token)) {
-            $share = $this->shareManager->getShareByToken($token);
-            $fileid = $share->getNodeId();
-            $fileowner = $share->getShareOwner();
-
-            //\OCP\Util::writeLog('audioplayer', 'fileid: '.$fileid, \OCP\Util::DEBUG);
-            //\OCP\Util::writeLog('audioplayer', 'fileowner: '.$fileowner, \OCP\Util::DEBUG);
-
-            $SQL = "SELECT `AT`.`title`,`AG`.`name` AS `genre`,`AB`.`name` AS `album`,`AT`.`artist_id`,
-					`AT`.`length`,`AT`.`bitrate`,`AT`.`year`,`AA`.`name` AS `artist`,
-					ROUND((`AT`.`bitrate` / 1000 ),0) AS `bitrate`, `AT`.`disc`,
-					`AT`.`number`, `AT`.`composer`, `AT`.`subtitle`, `AT`.`mimetype`, `AB`.`id` AS `album_id` , `AB`.`artist_id` AS `albumArtist_id`
-					, `AT`.`isrc` , `AT`.`copyright`
-						FROM `*PREFIX*audioplayer_tracks` `AT`
-						LEFT JOIN `*PREFIX*audioplayer_artists` `AA` ON `AT`.`artist_id` = `AA`.`id`
-						LEFT JOIN `*PREFIX*audioplayer_genre` `AG` ON `AT`.`genre_id` = `AG`.`id`
-						LEFT JOIN `*PREFIX*audioplayer_albums` `AB` ON `AT`.`album_id` = `AB`.`id`
-			 			WHERE  `AT`.`user_id` = ? AND `AT`.`file_id` = ?
-			 			ORDER BY `AT`.`album_id` ASC,`AT`.`number` ASC
-			 			";
-
-            $stmt = $this->db->prepare($SQL);
-            $stmt->execute(array($fileowner, $fileid));
-            $row = $stmt->fetch();
-
-            if (isset($row['title'])) {
-                $artist = $this->DBController->loadArtistsToAlbum($row['album_id'], $row['albumArtist_id']);
-                $row['albumartist'] = $artist;
-
-                if ($row['year'] === '0') $row['year'] = $this->l10n->t('Unknown');
-
-                $result = [
-                    'status' => 'success',
-                    'data' => $row];
-            } else {
-                $result = [
-                    'status' => 'error',
-                    'data' => 'nodata'];
-            }
-            return new JSONResponse($result);
+        if (empty($token)) {
+            return new JSONResponse(['status' => 'error', 'data' => 'nodata']);
         }
+
+        $row = $this->service->getPublicAudioInfo($token);
+        if ($row) {
+            $result = ['status' => 'success', 'data' => $row];
+        } else {
+            $result = ['status' => 'error', 'data' => 'nodata'];
+        }
+
+        return new JSONResponse($result);
     }
 
     /**
@@ -121,23 +65,13 @@ class MusicController extends Controller
      */
     public function getPublicAudioStream($token, $file)
     {
-        if (!empty($token)) {
-            $share = $this->shareManager->getShareByToken($token);
-            $fileowner = $share->getShareOwner();
-
-            // Setup filesystem
-            $nodes = $this->rootFolder->getUserFolder($fileowner)->getById($share->getNodeId());
-            $pfile = array_shift($nodes);
-            $path = $pfile->getPath();
-            $segments = explode('/', trim($path, '/'), 3);
-            $startPath = $segments[2];
-
-            $filenameAudio = $startPath . '/' . rawurldecode($file);
-
-            \OC::$server->getSession()->close();
-            $stream = new \OCA\audioplayer\Http\AudioStream($filenameAudio, $fileowner);
-            $stream->start();
+        if (empty($token)) {
+            return;
         }
+
+        $stream = $this->service->createPublicAudioStream($token, $file);
+        \OC::$server->getSession()->close();
+        $stream->start();
     }
 
     /**
@@ -148,21 +82,8 @@ class MusicController extends Controller
      */
     public function getAudioStream($file, $t)
     {
-
-        if ($t) {
-            $fileId = $this->DBController->getFileId($t);
-            $nodes = $this->rootFolder->getUserFolder($this->userId)->getById($fileId);
-            $file = array_shift($nodes);
-            $path = $file->getPath();
-            $segments = explode('/', trim($path, '/'), 3);
-            $filename = $segments[2];
-        } else {
-            $filename = rawurldecode($file);
-        }
-
-        $user = $this->userId;
+        $stream = $this->service->createAudioStream($file, $t);
         \OC::$server->getSession()->close();
-        $stream = new \OCA\audioplayer\Http\AudioStream($filename, $user);
         $stream->start();
     }
 }

--- a/lib/DB/MusicMapper.php
+++ b/lib/DB/MusicMapper.php
@@ -1,0 +1,114 @@
+<?php
+namespace OCA\audioplayer\DB;
+
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class MusicMapper
+{
+    private IDBConnection $db;
+    private IL10N $l10n;
+
+    public function __construct(IDBConnection $db, IL10N $l10n)
+    {
+        $this->db = $db;
+        $this->l10n = $l10n;
+    }
+
+    public function getTrackInfoForFile(string $userId, int $fileId): ?array
+    {
+        $qb = $this->db->getQueryBuilder();
+
+        $bitrateFunction = $qb->createFunction('ROUND((' . $qb->getColumnName('AT.bitrate') . ' / 1000),0)');
+
+        $qb->select('AT.title')
+            ->selectAlias('AG.name', 'genre')
+            ->selectAlias('AB.name', 'album')
+            ->addSelect('AT.artist_id')
+            ->addSelect('AT.length')
+            ->addSelect('AT.bitrate')
+            ->addSelect('AT.year')
+            ->selectAlias('AA.name', 'artist')
+            ->selectAlias($bitrateFunction, 'bitrate')
+            ->addSelect('AT.disc')
+            ->addSelect('AT.number')
+            ->addSelect('AT.composer')
+            ->addSelect('AT.subtitle')
+            ->addSelect('AT.mimetype')
+            ->selectAlias('AB.id', 'album_id')
+            ->selectAlias('AB.artist_id', 'albumArtist_id')
+            ->addSelect('AT.isrc')
+            ->addSelect('AT.copyright')
+            ->from('audioplayer_tracks', 'AT')
+            ->leftJoin('AT', 'audioplayer_artists', 'AA', $qb->expr()->eq('AT.artist_id', 'AA.id'))
+            ->leftJoin('AT', 'audioplayer_genre', 'AG', $qb->expr()->eq('AT.genre_id', 'AG.id'))
+            ->leftJoin('AT', 'audioplayer_albums', 'AB', $qb->expr()->eq('AT.album_id', 'AB.id'))
+            ->where($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('AT.file_id', $qb->createNamedParameter($fileId)))
+            ->orderBy('AT.album_id', 'ASC')
+            ->addOrderBy('AT.number', 'ASC');
+
+        $statement = $qb->execute();
+        $row = $statement->fetch();
+        $statement->closeCursor();
+
+        return $row ?: null;
+    }
+
+    public function loadArtistsToAlbum(int $albumId, int $artistId): string
+    {
+        if ($artistId !== 0) {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('name')
+                ->from('audioplayer_artists')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($artistId)));
+
+            $statement = $qb->execute();
+            $row = $statement->fetch();
+            $statement->closeCursor();
+
+            return $row['name'] ?? '';
+        }
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectDistinct('artist_id')
+            ->from('audioplayer_tracks')
+            ->where($qb->expr()->eq('album_id', $qb->createNamedParameter($albumId)));
+
+        $statement = $qb->execute();
+        $artist = $statement->fetch();
+        $rowCount = $statement->rowCount();
+        $statement->closeCursor();
+
+        if ($rowCount === 1 && $artist) {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('name')
+                ->from('audioplayer_artists')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($artist['artist_id'])));
+
+            $statement = $qb->execute();
+            $row = $statement->fetch();
+            $statement->closeCursor();
+
+            return $row['name'] ?? '';
+        }
+
+        return (string)$this->l10n->t('Various Artists');
+    }
+
+    public function getFileId(string $userId, int $trackId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('file_id')
+            ->from('audioplayer_tracks')
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($trackId)));
+
+        $statement = $qb->execute();
+        $row = $statement->fetch();
+        $statement->closeCursor();
+
+        return (int)($row['file_id'] ?? 0);
+    }
+}

--- a/lib/Service/MusicService.php
+++ b/lib/Service/MusicService.php
@@ -59,7 +59,7 @@ class MusicService
         return new AudioStream($filenameAudio, $fileOwner);
     }
 
-    public function createAudioStream(string $file, ?string $t): AudioStream
+    public function createAudioStream(?string $file, ?string $t): AudioStream
     {
         if ($t) {
             $fileId = $this->mapper->getFileId($this->userId, (int)$t);

--- a/lib/Service/MusicService.php
+++ b/lib/Service/MusicService.php
@@ -1,0 +1,77 @@
+<?php
+namespace OCA\audioplayer\Service;
+
+use OCA\audioplayer\DB\MusicMapper;
+use OCA\audioplayer\Http\AudioStream;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
+use OCP\Share\IManager;
+
+class MusicService
+{
+    private string $userId;
+    private IL10N $l10n;
+    private IManager $shareManager;
+    private IRootFolder $rootFolder;
+    private MusicMapper $mapper;
+
+    public function __construct(string $userId, IL10N $l10n, IManager $shareManager, IRootFolder $rootFolder, MusicMapper $mapper)
+    {
+        $this->userId = $userId;
+        $this->l10n = $l10n;
+        $this->shareManager = $shareManager;
+        $this->rootFolder = $rootFolder;
+        $this->mapper = $mapper;
+    }
+
+    public function getPublicAudioInfo(string $token): ?array
+    {
+        $share = $this->shareManager->getShareByToken($token);
+        $fileId = $share->getNodeId();
+        $fileOwner = $share->getShareOwner();
+
+        $row = $this->mapper->getTrackInfoForFile($fileOwner, (int)$fileId);
+        if (!$row) {
+            return null;
+        }
+
+        $artist = $this->mapper->loadArtistsToAlbum((int)$row['album_id'], (int)$row['albumArtist_id']);
+        $row['albumartist'] = $artist;
+        if ($row['year'] === '0') {
+            $row['year'] = $this->l10n->t('Unknown');
+        }
+        return $row;
+    }
+
+    public function createPublicAudioStream(string $token, string $file): AudioStream
+    {
+        $share = $this->shareManager->getShareByToken($token);
+        $fileOwner = $share->getShareOwner();
+
+        $nodes = $this->rootFolder->getUserFolder($fileOwner)->getById($share->getNodeId());
+        $pfile = array_shift($nodes);
+        $path = $pfile->getPath();
+        $segments = explode('/', trim($path, '/'), 3);
+        $startPath = $segments[2];
+
+        $filenameAudio = $startPath . '/' . rawurldecode($file);
+
+        return new AudioStream($filenameAudio, $fileOwner);
+    }
+
+    public function createAudioStream(string $file, ?string $t): AudioStream
+    {
+        if ($t) {
+            $fileId = $this->mapper->getFileId($this->userId, (int)$t);
+            $nodes = $this->rootFolder->getUserFolder($this->userId)->getById($fileId);
+            $fileNode = array_shift($nodes);
+            $path = $fileNode->getPath();
+            $segments = explode('/', trim($path, '/'), 3);
+            $filename = $segments[2];
+        } else {
+            $filename = rawurldecode($file);
+        }
+
+        return new AudioStream($filename, $this->userId);
+    }
+}


### PR DESCRIPTION
## Summary
- migrate MusicMapper to use Nextcloud's query builder

## Testing
- `php -l lib/DB/MusicMapper.php`
- `php -l lib/Service/MusicService.php`
- `php -l lib/Controller/MusicController.php`

------
https://chatgpt.com/codex/tasks/task_e_6872825e946483338fcecc45bea1257f