### PR TITLE
Refactor settings controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.4.2 - 2025-07-12
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters
+### Changed
+- Refactor SettingController to use service and mapper
 
 ## 3.4.1 - 2023-12-11
 ### Fixed

--- a/lib/Db/StatsMapper.php
+++ b/lib/Db/StatsMapper.php
@@ -1,0 +1,52 @@
+<?php
+namespace OCA\audioplayer\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+class StatsMapper extends QBMapper
+{
+    public const TABLE_NAME = 'audioplayer_stats';
+
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct($db, self::TABLE_NAME);
+    }
+
+    public function findByUserAndTrack(string $userId, int $trackId): ?array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from(self::TABLE_NAME)
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('track_id', $qb->createNamedParameter($trackId)));
+        $result = $qb->execute();
+        $data = $result->fetch();
+        $result->closeCursor();
+
+        return $data ?: null;
+    }
+
+    public function updatePlayCount(int $id, int $playcount, int $playtime): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(self::TABLE_NAME)
+            ->set('playcount', $qb->createNamedParameter($playcount))
+            ->set('playtime', $qb->createNamedParameter($playtime))
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+        $qb->execute();
+    }
+
+    public function insertStat(string $userId, int $trackId, int $playtime, int $playcount): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->insert(self::TABLE_NAME)
+            ->setValue('user_id', $qb->createNamedParameter($userId))
+            ->setValue('track_id', $qb->createNamedParameter($trackId))
+            ->setValue('playtime', $qb->createNamedParameter($playtime))
+            ->setValue('playcount', $qb->createNamedParameter($playcount));
+        $qb->execute();
+
+        return (int)$this->db->lastInsertId(self::TABLE_NAME);
+    }
+}

--- a/lib/Service/SettingService.php
+++ b/lib/Service/SettingService.php
@@ -1,0 +1,92 @@
+<?php
+namespace OCA\audioplayer\Service;
+
+use OCP\IConfig;
+use OCP\Files\IRootFolder;
+use OCP\ITagManager;
+use OCA\audioplayer\Controller\DbController;
+use OCA\audioplayer\Db\StatsMapper;
+
+class SettingService
+{
+    private $appName;
+    private $config;
+    private $rootFolder;
+    private $tagManager;
+    private $dbController;
+    private $statsMapper;
+
+    public function __construct(
+        string $appName,
+        IConfig $config,
+        ITagManager $tagManager,
+        IRootFolder $rootFolder,
+        DbController $dbController,
+        StatsMapper $statsMapper
+    ) {
+        $this->appName = $appName;
+        $this->config = $config;
+        $this->tagManager = $tagManager;
+        $this->rootFolder = $rootFolder;
+        $this->dbController = $dbController;
+        $this->statsMapper = $statsMapper;
+    }
+
+    public function admin(string $type, string $value): void
+    {
+        $this->config->setAppValue($this->appName, $type, $value);
+    }
+
+    public function setValue(string $userId, string $type, string $value): void
+    {
+        $this->config->setUserValue($userId, $this->appName, $type, $value);
+    }
+
+    public function getValue(string $userId, string $type): string
+    {
+        return $this->config->getUserValue($userId, $this->appName, $type);
+    }
+
+    public function userPath(string $userId, string $path): bool
+    {
+        try {
+            $this->rootFolder->getUserFolder($userId)->get($path);
+        } catch (\OCP\Files\NotFoundException $e) {
+            return false;
+        }
+
+        if ($path[0] !== '/') {
+            $path = '/' . $path;
+        }
+        if ($path[strlen($path) - 1] !== '/') {
+            $path .= '/';
+        }
+        $this->config->setUserValue($userId, $this->appName, 'path', $path);
+        return true;
+    }
+
+    public function setFavorite(string $userId, int $trackId, string $isFavorite)
+    {
+        $tagger = $this->tagManager->load('files');
+        $fileId = $this->dbController->getFileId($trackId);
+
+        if ($isFavorite === 'true') {
+            return $tagger->removeFromFavorites($fileId);
+        }
+        return $tagger->addToFavorites($fileId);
+    }
+
+    public function setStatistics(string $userId, int $trackId)
+    {
+        $date = new \DateTime();
+        $playtime = $date->getTimestamp();
+
+        $row = $this->statsMapper->findByUserAndTrack($userId, $trackId);
+        if ($row !== null && isset($row['id'])) {
+            $playcount = (int)$row['playcount'] + 1;
+            $this->statsMapper->updatePlayCount((int)$row['id'], $playcount, $playtime);
+            return 'update';
+        }
+        return $this->statsMapper->insertStat($userId, $trackId, $playtime, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SettingService` for business logic
- add query builder `StatsMapper`
- delegate DB actions in `SettingController` to the new service and mapper
- document change in `CHANGELOG`

## Testing
- `php -l lib/Db/StatsMapper.php`
- `php -l lib/Service/SettingService.php`
- `php -l lib/Controller/SettingController.php`


------
https://chatgpt.com/codex/tasks/task_e_687285559bbc833399133145eed18858