### PR TITLE
Refactor PlaylistController into service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.4.2 - 2025-07-12
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters
+- Corrected playlist track existence query
 ### Changed
 - Moved playlist database logic to service layer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.4.2 - 2025-07-12
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters
+### Changed
+- Moved playlist database logic to service layer
 
 ## 3.4.1 - 2023-12-11
 ### Fixed

--- a/lib/Controller/PlaylistController.php
+++ b/lib/Controller/PlaylistController.php
@@ -18,6 +18,8 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IL10N;
 use OCP\IDBConnection;
+use OCA\audioplayer\Service\PlaylistService;
+use OCA\audioplayer\DB\PlaylistMapper;
 
 /**
  * Controller class for main page.
@@ -27,7 +29,7 @@ class PlaylistController extends Controller
 
     private $userId;
     private $l10n;
-    private $db;
+    private $service;
 
     public function __construct(
         $appName,
@@ -40,7 +42,8 @@ class PlaylistController extends Controller
         parent::__construct($appName, $request);
         $this->userId = $userId;
         $this->l10n = $l10n;
-        $this->db = $db;
+        $mapper = new PlaylistMapper($db);
+        $this->service = new PlaylistService($userId, $mapper);
     }
 
     /**
@@ -51,7 +54,7 @@ class PlaylistController extends Controller
     public function addPlaylist($playlist)
     {
         if ($playlist !== '') {
-            $aResult = $this->writePlaylistToDB($playlist);
+            $aResult = $this->service->addPlaylist($playlist);
             if ($aResult['msg'] === 'new') {
                 $result = [
                     'status' => 'success',
@@ -69,25 +72,6 @@ class PlaylistController extends Controller
         }
     }
 
-    /**
-     * @param $sName
-     * @return array
-     */
-    private function writePlaylistToDB($sName)
-    {
-        $stmt = $this->db->prepare('SELECT `id` FROM `*PREFIX*audioplayer_playlists` WHERE `user_id` = ? AND `name` = ?');
-        $stmt->execute(array($this->userId, $sName));
-        $row = $stmt->fetch();
-        if ($row) {
-            $result = ['msg' => 'exist', 'id' => $row['id']];
-        } else {
-            $stmt = $this->db->prepare('INSERT INTO `*PREFIX*audioplayer_playlists` (`user_id`,`name`) VALUES(?,?)');
-            $stmt->execute(array($this->userId, $sName));
-            $insertid = $this->db->lastInsertId('*PREFIX*audioplayer_playlists');
-            $result = ['msg' => 'new', 'id' => $insertid];
-        }
-        return $result;
-    }
 
     /**
      * @NoAdminRequired
@@ -99,7 +83,7 @@ class PlaylistController extends Controller
     public function updatePlaylist($plId, $newname)
     {
 
-        if ($this->updatePlaylistToDB($plId, $newname)) {
+        if ($this->service->updatePlaylist($plId, $newname)) {
             $params = [
                 'status' => 'success',
             ];
@@ -112,12 +96,6 @@ class PlaylistController extends Controller
         return new JSONResponse($params);
     }
 
-    private function updatePlaylistToDB($id, $sName)
-    {
-        $stmt = $this->db->prepare('UPDATE `*PREFIX*audioplayer_playlists` SET `name` = ? WHERE `user_id`= ? AND `id`= ?');
-        $stmt->execute(array($sName, $this->userId, $id));
-        return true;
-    }
 
     /**
      * @NoAdminRequired
@@ -128,16 +106,7 @@ class PlaylistController extends Controller
      */
     public function addTrackToPlaylist($playlistid, $songid, $sorting)
     {
-        $stmt = $this->db->prepare('SELECT COUNT(*) AS tracks FROM `*PREFIX*audioplayer_playlist_tracks` WHERE `playlist_id` = ? AND `track_id` = ?');
-        $stmt->execute(array($playlistid, $songid));
-        $row = $stmt->fetch();
-        if ($row['tracks']) {
-            return false;
-        } else {
-            $stmt = $this->db->prepare('INSERT INTO `*PREFIX*audioplayer_playlist_tracks` (`playlist_id`,`track_id`,`sortorder`) VALUES(?,?,?)');
-            $stmt->execute(array($playlistid, $songid, (int)$sorting));
-            return true;
-        }
+        return $this->service->addTrackToPlaylist((int)$playlistid, (int)$songid, (int)$sorting);
     }
 
     /**
@@ -149,12 +118,7 @@ class PlaylistController extends Controller
     public function sortPlaylist($playlistid, $songids)
     {
         $iTrackIds = explode(';', $songids);
-        $counter = 1;
-        foreach ($iTrackIds as $trackId) {
-            $stmt = $this->db->prepare('UPDATE `*PREFIX*audioplayer_playlist_tracks` SET `sortorder` = ? WHERE `playlist_id` = ? AND `track_id` = ?');
-            $stmt->execute(array($counter, $playlistid, $trackId));
-            $counter++;
-        }
+        $this->service->sortPlaylist((int)$playlistid, $iTrackIds);
         $result = [
             'status' => 'success',
             'msg' => (string)$this->l10n->t('Sorting Playlist success! Playlist reloaded!')
@@ -170,15 +134,7 @@ class PlaylistController extends Controller
      */
     public function removeTrackFromPlaylist($playlistid, $trackid)
     {
-        try {
-            $sql = 'DELETE FROM `*PREFIX*audioplayer_playlist_tracks` '
-                . 'WHERE `playlist_id` = ? AND `track_id` = ?';
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute(array($playlistid, $trackid));
-        } catch (\Exception $e) {
-            return false;
-        }
-        return true;
+        return $this->service->removeTrackFromPlaylist((int)$playlistid, (int)$trackid);
     }
 
     /**
@@ -188,17 +144,7 @@ class PlaylistController extends Controller
      */
     public function removePlaylist($playlistid)
     {
-        try {
-            $sql = 'DELETE FROM `*PREFIX*audioplayer_playlists` '
-                . 'WHERE `id` = ? AND `user_id` = ?';
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute(array($playlistid, $this->userId));
-
-            $sql = 'DELETE FROM `*PREFIX*audioplayer_playlist_tracks` '
-                . 'WHERE `playlist_id` = ?';
-            $stmt = $this->db->prepare($sql);
-            $stmt->execute(array($playlistid));
-        } catch (\Exception $e) {
+        if (!$this->service->removePlaylist((int)$playlistid)) {
             return false;
         }
 

--- a/lib/DB/PlaylistMapper.php
+++ b/lib/DB/PlaylistMapper.php
@@ -1,0 +1,112 @@
+<?php
+namespace OCA\audioplayer\DB;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class PlaylistMapper extends QBMapper
+{
+    public const PLAYLIST_TABLE = 'audioplayer_playlists';
+    public const TRACK_TABLE = 'audioplayer_playlist_tracks';
+
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct($db, self::PLAYLIST_TABLE);
+    }
+
+    public function findByUserAndName(string $userId, string $name): ?int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id')
+            ->from(self::PLAYLIST_TABLE)
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('name', $qb->createNamedParameter($name)));
+        $stmt = $qb->execute();
+        $row = $stmt->fetch();
+        $stmt->closeCursor();
+        return $row ? (int)$row['id'] : null;
+    }
+
+    public function insertPlaylist(string $userId, string $name): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->insert(self::PLAYLIST_TABLE)
+            ->values([
+                'user_id' => $qb->createNamedParameter($userId),
+                'name' => $qb->createNamedParameter($name),
+            ])->execute();
+        return (int)$this->db->lastInsertId('*PREFIX*' . self::PLAYLIST_TABLE);
+    }
+
+    public function updatePlaylistName(int $id, string $userId, string $name): bool
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(self::PLAYLIST_TABLE)
+            ->set('name', $qb->createNamedParameter($name))
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($id)))
+            ->execute();
+        return true;
+    }
+
+    public function trackExists(int $playlistId, int $trackId): bool
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectAlias($qb->func()->count('id'), 'tracks')
+            ->from(self::TRACK_TABLE)
+            ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter($playlistId)))
+            ->andWhere($qb->expr()->eq('track_id', $qb->createNamedParameter($trackId)));
+        $stmt = $qb->execute();
+        $row = $stmt->fetch();
+        $stmt->closeCursor();
+        return (int)$row['tracks'] > 0;
+    }
+
+    public function insertTrack(int $playlistId, int $trackId, int $sortOrder): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->insert(self::TRACK_TABLE)
+            ->values([
+                'playlist_id' => $qb->createNamedParameter($playlistId),
+                'track_id' => $qb->createNamedParameter($trackId),
+                'sortorder' => $qb->createNamedParameter($sortOrder),
+            ])->execute();
+    }
+
+    public function updateTrackOrder(int $playlistId, int $trackId, int $sortOrder): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update(self::TRACK_TABLE)
+            ->set('sortorder', $qb->createNamedParameter($sortOrder))
+            ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter($playlistId)))
+            ->andWhere($qb->expr()->eq('track_id', $qb->createNamedParameter($trackId)))
+            ->execute();
+    }
+
+    public function deleteTrack(int $playlistId, int $trackId): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(self::TRACK_TABLE)
+            ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter($playlistId)))
+            ->andWhere($qb->expr()->eq('track_id', $qb->createNamedParameter($trackId)))
+            ->execute();
+    }
+
+    public function deletePlaylist(int $playlistId, string $userId): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(self::PLAYLIST_TABLE)
+            ->where($qb->expr()->eq('id', $qb->createNamedParameter($playlistId)))
+            ->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->execute();
+    }
+
+    public function deletePlaylistTracks(int $playlistId): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(self::TRACK_TABLE)
+            ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter($playlistId)))
+            ->execute();
+    }
+}

--- a/lib/DB/PlaylistMapper.php
+++ b/lib/DB/PlaylistMapper.php
@@ -53,7 +53,7 @@ class PlaylistMapper extends QBMapper
     public function trackExists(int $playlistId, int $trackId): bool
     {
         $qb = $this->db->getQueryBuilder();
-        $qb->selectAlias($qb->func()->count('id'), 'tracks')
+        $qb->selectAlias($qb->func()->count('track_id'), 'tracks')
             ->from(self::TRACK_TABLE)
             ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter($playlistId)))
             ->andWhere($qb->expr()->eq('track_id', $qb->createNamedParameter($trackId)));

--- a/lib/Service/PlaylistService.php
+++ b/lib/Service/PlaylistService.php
@@ -1,0 +1,66 @@
+<?php
+namespace OCA\audioplayer\Service;
+
+use OCA\audioplayer\DB\PlaylistMapper;
+
+class PlaylistService
+{
+    private $userId;
+    private $mapper;
+
+    public function __construct(string $userId, PlaylistMapper $mapper)
+    {
+        $this->userId = $userId;
+        $this->mapper = $mapper;
+    }
+
+    public function addPlaylist(string $name): array
+    {
+        $existing = $this->mapper->findByUserAndName($this->userId, $name);
+        if ($existing !== null) {
+            return ['msg' => 'exist', 'id' => $existing];
+        }
+
+        $id = $this->mapper->insertPlaylist($this->userId, $name);
+        return ['msg' => 'new', 'id' => $id];
+    }
+
+    public function updatePlaylist(int $playlistId, string $name): bool
+    {
+        return $this->mapper->updatePlaylistName($playlistId, $this->userId, $name);
+    }
+
+    public function addTrackToPlaylist(int $playlistId, int $trackId, int $order): bool
+    {
+        if ($this->mapper->trackExists($playlistId, $trackId)) {
+            return false;
+        }
+        $this->mapper->insertTrack($playlistId, $trackId, $order);
+        return true;
+    }
+
+    public function sortPlaylist(int $playlistId, array $trackIds): void
+    {
+        $counter = 1;
+        foreach ($trackIds as $trackId) {
+            if ($trackId === '') {
+                continue;
+            }
+            $this->mapper->updateTrackOrder($playlistId, (int)$trackId, $counter);
+            $counter++;
+        }
+    }
+
+    public function removeTrackFromPlaylist(int $playlistId, int $trackId): bool
+    {
+        $this->mapper->deleteTrack($playlistId, $trackId);
+        return true;
+    }
+
+    public function removePlaylist(int $playlistId): bool
+    {
+        $this->mapper->deletePlaylist($playlistId, $this->userId);
+        $this->mapper->deletePlaylistTracks($playlistId);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- move playlist DB calls into PlaylistService and PlaylistMapper
- update PlaylistController to use the service
- document change in CHANGELOG

## Testing
- `php -l lib/DB/PlaylistMapper.php`
- `php -l lib/Service/PlaylistService.php`
- `php -l lib/Controller/PlaylistController.php`


------
https://chatgpt.com/codex/tasks/task_e_687285c60d6c83338797a2e1e8c1d5db