### PR TITLE
Refactor jQuery usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - refactored MusicController into service and mapper
 - migrated MusicMapper to use QueryBuilder
 - mprove cover image response performance and stability
+- replaced jQuery usage with vanilla JS in settings, sharing and viewer scripts
 
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters

--- a/js/settings/personal.js
+++ b/js/settings/personal.js
@@ -11,37 +11,32 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', function () {
-    $('#cyrillic_user').on('click', function () {
-        var user_value;
-        if ($('#cyrillic_user').prop('checked')) {
-            user_value = 'checked';
-        } else {
-            user_value = '';
-        }
-        $.ajax({
-            type: 'GET',
-            url: OC.generateUrl('apps/audioplayer/setvalue'),
-            data: {
-                'type': 'cyrillic',
-                'value': user_value
-            },
-            success: function () {
-                OCP.Toast.success(t('audioplayer', 'Saved'));
-            }
+    var cyrillic = document.getElementById('cyrillic_user');
+    cyrillic.addEventListener('click', function () {
+        var user_value = cyrillic.checked ? 'checked' : '';
+        var params = new URLSearchParams({ type: 'cyrillic', value: user_value });
+        fetch(OC.generateUrl('apps/audioplayer/setvalue') + '?' + params.toString(), {
+            method: 'GET'
+        }).then(function () {
+            OCP.Toast.success(t('audioplayer', 'Saved'));
         });
     });
 
     /*
  * Collection path
  */
-    var $path = $('#audio-path');
-    $path.on('click', function () {
+    var pathInput = document.getElementById('audio-path');
+    pathInput.addEventListener('click', function () {
         OC.dialogs.filepicker(
             t('audioplayer', 'Select a single folder with audio files'),
             function (path) {
-                if ($path.val() !== path) {
-                    $path.val(path);
-                    $.post(OC.generateUrl('apps/audioplayer/userpath'), {value: path}, function (data) {
+                if (pathInput.value !== path) {
+                    pathInput.value = path;
+                    fetch(OC.generateUrl('apps/audioplayer/userpath'), {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ value: path })
+                    }).then(function (response) { return response.json(); }).then(function (data) {
                         if (!data.success) {
                             OCP.Toast.error(t('audioplayer', 'Invalid path!'));
                         } else {
@@ -59,16 +54,16 @@ document.addEventListener('DOMContentLoaded', function () {
     var supported_types = '';
     var nsupported_types = '';
     var mimeTypes = ['audio/mpeg', 'audio/mp4', 'audio/ogg', 'audio/wav', 'audio/flac', 'audio/x-aiff', 'audio/aac'];
-    const audio = document.createElement('audio');
+    var audio = document.createElement('audio');
 
-    mimeTypes.forEach((element) => {
+    mimeTypes.forEach(function (element) {
         if (audio.canPlayType(element)) {
-            supported_types = supported_types + element + ', ';
+            supported_types += element + ', ';
         } else {
-            nsupported_types = nsupported_types + element + ', ';
+            nsupported_types += element + ', ';
         }
     });
 
-    $('#browser_yes').html(supported_types);
-    $('#browser_no').html(nsupported_types);
+    document.getElementById('browser_yes').innerHTML = supported_types;
+    document.getElementById('browser_no').innerHTML = nsupported_types;
 });

--- a/js/sharing/sharing.js
+++ b/js/sharing/sharing.js
@@ -13,79 +13,81 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', function () {
-    //if ($('#header').hasClass('share-file')) {
     var mime_array = ['audio/mpeg', 'audio/mp4', 'audio/m4b', 'audio/ogg', 'audio/wav', 'audio/flac', 'audio/x-aiff', 'audio/aac'];
-    var mimeType = $('#mimetype').val();
-    var sharingToken = $('#sharingToken');
+    var mimeType = document.getElementById('mimetype').value;
+    var sharingToken = document.getElementById('sharingToken');
 
-    var token = (sharingToken.val() !== undefined) ? sharingToken.val() : '';
+    var token = sharingToken ? sharingToken.value : '';
     if (mime_array.indexOf(mimeType) !== -1) {
+        var imgFrame = document.getElementById('imgframe');
+        imgFrame.style.maxWidth = '450px';
 
-        var imgFrame = $('#imgframe');
-        imgFrame.css({'max-width': '450px'});
-
-        if (imgFrame.find('audio').length === 0) {
-            var downloadURL = $('#downloadURL').val();
-            var audioTag = '<audio tabindex="0" controls preload="none" style="width: 100%;"> <source src="' + downloadURL + '" type="' + mimeType + '"/> </audio>';
-            imgFrame.append(audioTag);
+        if (imgFrame.querySelectorAll('audio').length === 0) {
+            var downloadURL = document.getElementById('downloadURL').value;
+            var audioTag = document.createElement('audio');
+            audioTag.tabIndex = 0;
+            audioTag.controls = true;
+            audioTag.preload = 'none';
+            audioTag.style.width = '100%';
+            var source = document.createElement('source');
+            source.src = downloadURL;
+            source.type = mimeType;
+            audioTag.appendChild(source);
+            imgFrame.appendChild(audioTag);
         }
 
-        imgFrame.after($('<div/>').attr('id', 'id3'));
-        var ajaxurl = OC.generateUrl('apps/audioplayer/getpublicaudioinfo?token={token}', {'token': token}, {escape: false});
+        var id3 = document.createElement('div');
+        id3.id = 'id3';
+        imgFrame.insertAdjacentElement('afterend', id3);
+        var ajaxurl = OC.generateUrl('apps/audioplayer/getpublicaudioinfo?token={token}', { 'token': token }, { escape: false });
 
-        $.ajax({
-            type: 'GET',
-            url: ajaxurl,
-            success: function (jsondata) {
+        fetch(ajaxurl)
+            .then(function (response) { return response.json(); })
+            .then(function (jsondata) {
                 if (jsondata.status === 'success') {
-                    var $id3 = $('#id3');
-                    if (jsondata.data.title !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Title') + ': ')).append($('<span/>').text(jsondata.data.title)));
-                    }
-                    if (jsondata.data.subtitle !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Subtitle') + ': ')).append($('<span/>').text(jsondata.data.subtitle)));
-                    }
-                    if (jsondata.data.artist !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Artist') + ': ')).append($('<span/>').text(jsondata.data.artist)));
-                    }
-                    if (jsondata.data.albumartist !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Album Artist') + ': ')).append($('<span/>').text(jsondata.data.albumartist)));
-                    }
-                    if (jsondata.data.composer !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Composer') + ': ')).append($('<span/>').text(jsondata.data.composer)));
-                    }
-                    if (jsondata.data.album !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Album') + ': ')).append($('<span/>').text(jsondata.data.album)));
-                    }
-                    if (jsondata.data.genre !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Genre') + ': ')).append($('<span/>').text(jsondata.data.genre)));
-                    }
-                    if (jsondata.data.year !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Year') + ': ')).append($('<span/>').text(jsondata.data.year)));
-                    }
+                    var id3elem = document.getElementById('id3');
+                    var addRow = function (label, value) {
+                        if (value !== '') {
+                            var div = document.createElement('div');
+                            var bold = document.createElement('b');
+                            bold.textContent = label + ': ';
+                            var span = document.createElement('span');
+                            span.textContent = value;
+                            div.appendChild(bold);
+                            div.appendChild(span);
+                            id3elem.appendChild(div);
+                        }
+                    };
+                    addRow(t('audioplayer', 'Title'), jsondata.data.title);
+                    addRow(t('audioplayer', 'Subtitle'), jsondata.data.subtitle);
+                    addRow(t('audioplayer', 'Artist'), jsondata.data.artist);
+                    addRow(t('audioplayer', 'Album Artist'), jsondata.data.albumartist);
+                    addRow(t('audioplayer', 'Composer'), jsondata.data.composer);
+                    addRow(t('audioplayer', 'Album'), jsondata.data.album);
+                    addRow(t('audioplayer', 'Genre'), jsondata.data.genre);
+                    addRow(t('audioplayer', 'Year'), jsondata.data.year);
                     if (jsondata.data.number !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Disc') + '-' + t('audioplayer', 'Track') + ': ')).append($('<span/>').text(jsondata.data.disc + '-' + jsondata.data.number)));
+                        addRow(t('audioplayer', 'Disc') + '-' + t('audioplayer', 'Track'), jsondata.data.disc + '-' + jsondata.data.number);
                     }
-                    if (jsondata.data.length !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Length') + ': ')).append($('<span/>').text(jsondata.data.length)));
-                    }
+                    addRow(t('audioplayer', 'Length'), jsondata.data.length);
                     if (jsondata.data.bitrate !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'Bitrate') + ': ')).append($('<span/>').text(jsondata.data.bitrate + ' kbps')));
+                        addRow(t('audioplayer', 'Bitrate'), jsondata.data.bitrate + ' kbps');
                     }
-                    if (jsondata.data.mimetype !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'MIME type') + ': ')).append($('<span/>').text(jsondata.data.mimetype)));
-                    }
-                    if (jsondata.data.isrc !== '') {
-                        $id3.append($('<div/>').append($('<b/>').text(t('audioplayer', 'ISRC') + ': ')).append($('<span/>').text(jsondata.data.isrc)));
-                    }
+                    addRow(t('audioplayer', 'MIME type'), jsondata.data.mimetype);
+                    addRow(t('audioplayer', 'ISRC'), jsondata.data.isrc);
                     if (jsondata.data.copyright !== '') {
-                        $id3.append($('<div/>').append($('<span/>').text(t('audioplayer', 'Copyright') + ' © ')).append($('<span/>').text(jsondata.data.copyright)));
+                        var div = document.createElement('div');
+                        var span1 = document.createElement('span');
+                        span1.textContent = t('audioplayer', 'Copyright') + ' © ';
+                        var span2 = document.createElement('span');
+                        span2.textContent = jsondata.data.copyright;
+                        div.appendChild(span1);
+                        div.appendChild(span2);
+                        id3elem.appendChild(div);
                     }
-                    $('.directDownload').css({'padding-top': '20px'});
-                    $('.publicpreview').css({'padding-top': '20px'});
+                    document.querySelectorAll('.directDownload').forEach(function (el) { el.style.paddingTop = '20px'; });
+                    document.querySelectorAll('.publicpreview').forEach(function (el) { el.style.paddingTop = '20px'; });
                 }
-            }
-        });
+            });
     }
-    //}
 });

--- a/js/viewer/search.js
+++ b/js/viewer/search.js
@@ -18,11 +18,14 @@
         attach: function(search) {
             search.setRenderer('audioplayer', this.renderResult);
         },
-        renderResult: function($row, item) {
-            $row.find('td.icon')
-                .css('background-image', 'url(' + OC.imagePath('audioplayer', 'app-dark') + ')')
-                .css('opacity', '.4');
-            return $row;
+        renderResult: function(row, item) {
+            var element = row instanceof HTMLElement ? row : row[0];
+            var icon = element.querySelector('td.icon');
+            if (icon) {
+                icon.style.backgroundImage = 'url(' + OC.imagePath('audioplayer', 'app-dark') + ')';
+                icon.style.opacity = '.4';
+            }
+            return element;
         }
     };
     OCA.Search.Audiplayer = Audiplayer;

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -23,7 +23,8 @@ function playFile(file, data) {
     file = encodeURIComponent(file);
     audioPlayer.file = file;
     audioPlayer.dir = data.dir;
-    var token = ($('#sharingToken').val() !== undefined) ? $('#sharingToken').val() : '';
+    var sharingToken = document.getElementById('sharingToken');
+    var token = (sharingToken && sharingToken.value !== undefined) ? sharingToken.value : '';
     var dirLoad = data.dir.substr(1);
     if (dirLoad !== '') {
         dirLoad = dirLoad + '/';
@@ -36,8 +37,12 @@ function playFile(file, data) {
     } else {
         audioPlayer.location = OC.generateUrl('apps/audioplayer/getaudiostream?file={file}', {'file': dirLoad + file}, {escape: true});
     }
-    audioPlayer.mime = data.$file.attr('data-mime');
-    data.$file.find('.thumbnail').html('<i class="ioc ioc-volume-up"  style="color:#fff;margin-left:5px; text-align:center;line-height:32px;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;font-size: 24px;"></i>');
+    var fileRow = data.$file && data.$file[0] ? data.$file[0] : data.file;
+    audioPlayer.mime = fileRow.getAttribute('data-mime');
+    var thumb = fileRow.querySelector('.thumbnail');
+    if (thumb) {
+        thumb.innerHTML = '<i class="ioc ioc-volume-up"  style="color:#fff;margin-left:5px; text-align:center;line-height:32px;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;font-size: 24px;"></i>';
+    }
 
     if (audioPlayer.player === null) {
         audioPlayer.player = document.createElement('audio');
@@ -46,7 +51,9 @@ function playFile(file, data) {
         audioPlayer.player.play();
     } else {
         audioPlayer.player.pause();
-        $('#filestable').find('.thumbnail i.ioc-volume-up').hide();
+        document.querySelectorAll('#filestable .thumbnail i.ioc-volume-up').forEach(function (el) {
+            el.style.display = 'none';
+        });
         audioPlayer.player = null;
     }
 }
@@ -72,7 +79,8 @@ function registerFileActions() {
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-    if (typeof OCA !== 'undefined' && typeof OCA.Files !== 'undefined' && typeof OCA.Files.fileActions !== 'undefined' && $('#header').hasClass('share-file') === false) {
+    var header = document.getElementById('header');
+    if (typeof OCA !== 'undefined' && typeof OCA.Files !== 'undefined' && typeof OCA.Files.fileActions !== 'undefined' && header && !header.classList.contains('share-file')) {
         registerFileActions();
     }
     return true;


### PR DESCRIPTION
## Summary
- drop all jQuery calls in settings, sharing and viewer scripts
- use plain JS to update settings UI and fetch data
- update changelog

## Testing
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_6872d4d77e188333a4328874a0abb201