### PR TITLE
Refactor CategoryController into service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - refactor cover retrieval logic
 - Moved playlist database logic to service layer
 - Refactor SettingController to use service and mapper
+- Refactored CategoryController into service and mapper
 
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters

--- a/lib/DB/CategoryMapper.php
+++ b/lib/DB/CategoryMapper.php
@@ -1,0 +1,272 @@
+<?php
+namespace OCA\audioplayer\DB;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IL10N;
+
+class CategoryMapper
+{
+    private IDBConnection $db;
+    private IL10N $l10n;
+
+    public function __construct(IDBConnection $db, IL10N $l10n)
+    {
+        $this->db = $db;
+        $this->l10n = $l10n;
+    }
+
+    public function getArtists(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectAlias('AT.artist_id', 'id')
+            ->addSelect('AA.name')
+            ->selectAlias($qb->func()->lower('AA.name'), 'lower')
+            ->from('audioplayer_tracks', 'AT')
+            ->leftJoin('AT', 'audioplayer_artists', 'AA', $qb->expr()->eq('AT.artist_id', 'AA.id'))
+            ->where($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)))
+            ->groupBy('AT.artist_id')
+            ->addGroupBy('AA.name')
+            ->orderBy($qb->func()->lower('AA.name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getGenres(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id')
+            ->addSelect('name')
+            ->selectAlias($qb->func()->lower('name'), 'lower')
+            ->from('audioplayer_genre')
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->orderBy($qb->func()->lower('name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getYears(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectDistinct('year', 'id')
+            ->addSelect('year', 'name')
+            ->from('audioplayer_tracks')
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->orderBy('year', 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getStreams(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectAlias('file_id', 'id')
+            ->addSelect('title AS name')
+            ->selectAlias($qb->func()->lower('title'), 'lower')
+            ->from('audioplayer_streams')
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->orderBy($qb->func()->lower('title'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getPlaylists(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id')
+            ->addSelect('name')
+            ->selectAlias($qb->func()->lower('name'), 'lower')
+            ->from('audioplayer_playlists')
+            ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
+            ->orderBy($qb->func()->lower('name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getFolders(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectAlias('FC.fileid', 'id')
+            ->addSelect('FC.name')
+            ->selectAlias($qb->func()->lower('FC.name'), 'lower')
+            ->from('audioplayer_tracks', 'AT')
+            ->join('AT', 'filecache', 'FC', $qb->expr()->eq('FC.fileid', 'AT.folder_id'))
+            ->where($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)))
+            ->groupBy('FC.fileid')
+            ->addGroupBy('FC.name')
+            ->orderBy($qb->func()->lower('FC.name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getAlbums(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('AB.id')
+            ->addSelect('AB.name')
+            ->selectAlias($qb->func()->lower('AB.name'), 'lower')
+            ->from('audioplayer_albums', 'AB')
+            ->where($qb->expr()->eq('AB.user_id', $qb->createNamedParameter($userId)))
+            ->orderBy($qb->func()->lower('AB.name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getAlbumArtists(string $userId): array
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectDistinct('AB.artist_id')
+            ->addSelect('AA.name')
+            ->selectAlias($qb->func()->lower('AA.name'), 'lower')
+            ->from('audioplayer_albums', 'AB')
+            ->join('AB', 'audioplayer_artists', 'AA', $qb->expr()->eq('AB.artist_id', 'AA.id'))
+            ->where($qb->expr()->eq('AB.user_id', $qb->createNamedParameter($userId)))
+            ->orderBy($qb->func()->lower('AA.name'), 'ASC');
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getAlbumCovers(string $userId, string $category, ?string $categoryId): array
+    {
+        $columnMap = [
+            'Artist' => 'AT.artist_id',
+            'Genre' => 'AT.genre_id',
+            'Album' => 'AB.id',
+            'Album Artist' => 'AB.artist_id',
+            'Year' => 'AT.year',
+            'Folder' => 'AT.folder_id',
+        ];
+        $qb = $this->db->getQueryBuilder();
+        $function = $qb->createFunction('CASE WHEN ' . $qb->getColumnName('AB.cover') . ' IS NOT NULL THEN ' . $qb->getColumnName('AB.id') . ' ELSE NULL END');
+        $qb->select('AB.id')
+            ->addSelect('AB.name')
+            ->selectAlias($qb->func()->lower('AB.name'), 'lower')
+            ->addSelect('AA.id AS art')
+            ->selectAlias($function, 'cid')
+            ->from('audioplayer_tracks', 'AT')
+            ->leftJoin('AT', 'audioplayer_albums', 'AB', $qb->expr()->eq('AT.album_id', 'AB.id'))
+            ->leftJoin('AB', 'audioplayer_artists', 'AA', $qb->expr()->eq('AB.artist_id', 'AA.id'))
+            ->where($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)))
+            ->groupBy('AB.id')
+            ->addGroupBy('AA.id')
+            ->addGroupBy('AB.name')
+            ->orderBy($qb->func()->lower('AB.name'), 'ASC');
+        if ($categoryId !== null && isset($columnMap[$category])) {
+            $qb->andWhere($qb->expr()->eq($columnMap[$category], $qb->createNamedParameter($categoryId)));
+        }
+        $statement = $qb->execute();
+        $rows = $statement->fetchAll();
+        $statement->closeCursor();
+        return $rows;
+    }
+
+    public function getTrackCount(string $category, string $categoryId, string $userId): int
+    {
+        $qb = $this->db->getQueryBuilder();
+        switch ($category) {
+            case 'Artist':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->eq('AT.artist_id', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Genre':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->eq('AT.genre_id', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Year':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->eq('AT.year', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Title':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->gt('AT.id', $qb->createNamedParameter(0)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Playlist':
+                $qb->selectAlias($qb->func()->count('track_id'), 'count')
+                    ->from('audioplayer_playlist_tracks')
+                    ->where($qb->expr()->eq('playlist_id', $qb->createNamedParameter((int)$categoryId)));
+                break;
+            case 'Folder':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->eq('AT.folder_id', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Album':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_tracks', 'AT')
+                    ->where($qb->expr()->eq('AT.album_id', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AT.user_id', $qb->createNamedParameter($userId)));
+                break;
+            case 'Album Artist':
+                $qb->selectAlias($qb->func()->count('AT.id'), 'count')
+                    ->from('audioplayer_albums', 'AB')
+                    ->join('AB', 'audioplayer_tracks', 'AT', $qb->expr()->eq('AB.id', 'AT.album_id'))
+                    ->where($qb->expr()->eq('AB.artist_id', $qb->createNamedParameter((int)$categoryId)))
+                    ->andWhere($qb->expr()->eq('AB.user_id', $qb->createNamedParameter($userId)));
+                break;
+            default:
+                return 0;
+        }
+        $statement = $qb->execute();
+        $row = $statement->fetch();
+        $statement->closeCursor();
+        return (int)($row['count'] ?? 0);
+    }
+
+    public function loadArtistsToAlbum(int $albumId, int $artistId): string
+    {
+        if ($artistId !== 0) {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('name')
+                ->from('audioplayer_artists')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($artistId)));
+            $statement = $qb->execute();
+            $row = $statement->fetch();
+            $statement->closeCursor();
+            return $row['name'] ?? '';
+        }
+        $qb = $this->db->getQueryBuilder();
+        $qb->selectDistinct('artist_id')
+            ->from('audioplayer_tracks')
+            ->where($qb->expr()->eq('album_id', $qb->createNamedParameter($albumId)));
+        $statement = $qb->execute();
+        $artist = $statement->fetch();
+        $rowCount = $statement->rowCount();
+        $statement->closeCursor();
+        if ($rowCount === 1 && $artist) {
+            $qb = $this->db->getQueryBuilder();
+            $qb->select('name')
+                ->from('audioplayer_artists')
+                ->where($qb->expr()->eq('id', $qb->createNamedParameter($artist['artist_id'])));
+            $statement = $qb->execute();
+            $row = $statement->fetch();
+            $statement->closeCursor();
+            return $row['name'] ?? '';
+        }
+        return (string)$this->l10n->t('Various Artists');
+    }
+}

--- a/lib/Service/CategoryService.php
+++ b/lib/Service/CategoryService.php
@@ -1,0 +1,99 @@
+<?php
+namespace OCA\audioplayer\Service;
+
+use OCA\audioplayer\Categories\Tag;
+use OCA\audioplayer\DB\CategoryMapper;
+use OCP\IL10N;
+
+class CategoryService
+{
+    private string $userId;
+    private IL10N $l10n;
+    private CategoryMapper $mapper;
+    private Tag $categoriesTag;
+
+    public function __construct(string $userId, IL10N $l10n, CategoryMapper $mapper, Tag $categoriesTag)
+    {
+        $this->userId = $userId;
+        $this->l10n = $l10n;
+        $this->mapper = $mapper;
+        $this->categoriesTag = $categoriesTag;
+    }
+
+    public function getCategoryItems(string $category): array
+    {
+        $items = [];
+        switch ($category) {
+            case 'Artist':
+                $items = $this->mapper->getArtists($this->userId);
+                break;
+            case 'Genre':
+                $items = $this->mapper->getGenres($this->userId);
+                break;
+            case 'Year':
+                $items = $this->mapper->getYears($this->userId);
+                break;
+            case 'Title':
+                $items[] = ['id' => '0', 'name' => $this->l10n->t('All Titles'), 'lower' => ''];
+                break;
+            case 'Playlist':
+                $items[] = ['id' => 'X1', 'name' => $this->l10n->t('Favorites')];
+                $items[] = ['id' => 'X2', 'name' => $this->l10n->t('Recently Added')];
+                $items[] = ['id' => 'X3', 'name' => $this->l10n->t('Recently Played')];
+                $items[] = ['id' => 'X4', 'name' => $this->l10n->t('Most Played')];
+                $items[] = ['id' => 'X5', 'name' => $this->l10n->t('50 Random Tracks')];
+                $items[] = ['id' => '', 'name' => ''];
+                foreach ($this->mapper->getStreams($this->userId) as $row) {
+                    unset($row['lower']);
+                    $row['id'] = 'S' . $row['id'];
+                    $items[] = $row;
+                }
+                $items[] = ['id' => '', 'name' => ''];
+                $items = array_merge($items, $this->mapper->getPlaylists($this->userId));
+                break;
+            case 'Folder':
+                $items = $this->mapper->getFolders($this->userId);
+                break;
+            case 'Album':
+                $items = $this->mapper->getAlbums($this->userId);
+                break;
+            case 'Album Artist':
+                $items = $this->mapper->getAlbumArtists($this->userId);
+                break;
+            case 'Tags':
+                $items = $this->categoriesTag->getCategoryItems();
+                // already includes count
+                return $items;
+        }
+
+        foreach ($items as &$row) {
+            if (($row['name'] === '0' || $row['name'] === '') && $category !== 'Title') {
+                $row['name'] = $this->l10n->t('Unknown');
+            }
+            $row['cnt'] = $this->mapper->getTrackCount($category, $row['id'], $this->userId);
+            unset($row['lower']);
+        }
+        return $items;
+    }
+
+    public function getCategoryItemCovers(string $category, ?string $categoryId): array
+    {
+        if ($category === 'Tags') {
+            return $this->categoriesTag->getCategoryItemCovers($categoryId);
+        }
+        $rows = $this->mapper->getAlbumCovers($this->userId, $category, $categoryId);
+        foreach ($rows as &$row) {
+            $row['art'] = $this->mapper->loadArtistsToAlbum((int)$row['id'], (int)$row['art']);
+            if ($row['name'] === '0' || $row['name'] === '') {
+                $row['name'] = $this->l10n->t('Unknown');
+            }
+            unset($row['lower']);
+        }
+        return $rows;
+    }
+
+    public function getTrackCount(string $category, string $categoryId): int
+    {
+        return $this->mapper->getTrackCount($category, $categoryId, $this->userId);
+    }
+}


### PR DESCRIPTION
## Summary
- move category logic into dedicated service and mapper
- use Query Builder for database access
- wire CategoryService through the controller constructor

## Testing
- `php -l lib/DB/CategoryMapper.php`
- `php -l lib/Service/CategoryService.php`
- `php -l lib/Controller/CategoryController.php`


------
https://chatgpt.com/codex/tasks/task_e_6873762e0bc4833380ee6c2309f35c1f