### PR TITLE
Fix keyboard control with open modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Audio Player project will be documented in this file.
 
 ### Fixed
 - PHP 8.4 compatibility for nullable parameters
+- avoid player pause/resume when space is pressed inside modal dialogs
 ### Changed
 - Refactor SidebarController into service and mapper
 - Converted DbController into DbMapper using Query Builder

--- a/js/app.js
+++ b/js/app.js
@@ -76,6 +76,12 @@ OCA.Audioplayer.Core = {
                 }
             }
 
+            // Do not process shortcuts when a modal dialog is open
+            const modal = document.querySelector('[role="dialog"][aria-modal="true"]');
+            if (modal && window.getComputedStyle(modal).display !== 'none') {
+                return;
+            }
+
             if (OCA.Audioplayer.Player) {
                 let currentVolume;
                 let newVolume;


### PR DESCRIPTION
## Summary
- prevent global player shortcuts when a modal dialog is visible
- note fix in changelog

## Testing
- `npx eslint js/app.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68740943a23c83339d0cd0be41e5a10f