### PR TITLE
Reset album counter for each user scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - PHP 8.4 compatibility for nullable parameters
 - avoid player pause/resume when space is pressed inside modal dialogs
 - [BUG] A song with title "0" cause scanner stopped to scan more music #601
+- reset album count between user scans
 
 ### Changed
 - Refactor SidebarController into service and mapper

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -144,6 +144,12 @@ class ScannerController extends Controller
             $output = new NullOutput();
         }
 
+        $this->iAlbumCount = 0;
+        $this->iDublicate = 0;
+        $this->numOfSongs = 0;
+        $this->parentIdPrevious = 0;
+        $this->folderPicture = false;
+
         $output->writeln("Start processing of <info>audio files</info>");
 
         $counter = 0;


### PR DESCRIPTION
## Summary
- reset scanner counters before each scan run
- note fix in changelog

## Testing
- `php -l lib/Controller/ScannerController.php`
- `composer validate --no-check-all --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_6874142e8d108333bea2fded1db6fc0c