### PR TITLE
Fix column layout shift on odd track counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - [BUG] A song with title "0" cause scanner stopped to scan more music #601
 - fixed controls freezing when previous is clicked on the first track
 - reset album count between occ user scans
+- fix column layout shift when selecting titles in cover view
 
 ### Changed
 - Refactor SidebarController into service and mapper

--- a/css/style.css
+++ b/css/style.css
@@ -773,6 +773,11 @@ i#scanAudiosFirst {
     float: left;
 }
 
+.songlist.two-column .albumwrapper li {
+    float: none;
+    break-inside: avoid;
+}
+
 .songcontainer span.number {
     position: relative;
     width: 30px;

--- a/css/style.scss
+++ b/css/style.scss
@@ -769,6 +769,11 @@ i#scanAudiosFirst {
   float: left;
 }
 
+.songlist.two-column .albumwrapper li {
+  float: none;
+  break-inside: avoid;
+}
+
 .songcontainer span.number {
   position: relative;
   width: 30px;


### PR DESCRIPTION
## Summary
- fix layout shift when clicking track in cover view by disabling float and preventing column breaks
- update changelog

## Testing
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_6874180701888333ba97b73d2429d7f6