### PR TITLE
Fix library scan crash with PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - reset album count between occ user scans
 - cover view pushes full rows down when the song list is open
 - [BUG] Albums with an odd number of tracks have weird behavior #594
+- catch getID3 TypeError during library scan
 
 ### Changed
 - Refactor SidebarController into service and mapper


### PR DESCRIPTION
## Summary
- catch `TypeError` raised by getID3 when scanning audio files
- log a descriptive error and continue scanning
- document fix in the changelog

## Testing
- `php -l lib/Controller/ScannerController.php`
- `find lib -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68741efd959c8333bfeb5682045189a9