### PR TITLE
Fix preloading of next track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.5.2 - pending
 ### Changed
 - optimized album art search to reduce filesystem access
+### Fixed
+- next track was not preloaded for gapless playback
 
 ## 3.5.1 - 2025-07-18
 ### Fixed

--- a/js/player.js
+++ b/js/player.js
@@ -147,14 +147,16 @@ OCA.Audioplayer.Player = {
      */
     preloadNext: function () {
         const nextIndex = OCA.Audioplayer.Player.currentTrackIndex + 1;
+        const preload = OCA.Audioplayer.Player.preloadAudio;
         if (nextIndex < OCA.Audioplayer.Player.html5Audio.childElementCount) {
             const nextTrack = OCA.Audioplayer.Player.html5Audio.children[nextIndex];
             if (nextTrack.dataset.canPlayMime !== 'false') {
-                OCA.Audioplayer.Player.preloadAudio.setAttribute('src', nextTrack.src);
-                OCA.Audioplayer.Player.preloadAudio.load();
+                preload.pause();
+                preload.src = nextTrack.src;
+                preload.load();
             }
         } else {
-            OCA.Audioplayer.Player.preloadAudio.removeAttribute('src');
+            preload.removeAttribute('src');
         }
     },
 


### PR DESCRIPTION
## Summary
- ensure preload audio element fetches the upcoming song
- document fix in changelog

## Testing
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_687e62bd7c108333ba8c3a0531964d18