### PR TITLE
Fix scan progress streaming headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Audio Player project will be documented in this file.
 - Dashboard widget not working #639
 - compatibility occ commands
 - compatibility event listeners
+- eliminated header warnings during streaming scan progress updates
 
 ## 3.5.1 - 2025-07-18
 ### Fixed


### PR DESCRIPTION
## Summary
- restructure the scan controller to stream progress via `StreamedResponse`, preventing header warnings while updates are emitted
- document the fix in the changelog

## Testing
- php -l lib/Controller/ScannerController.php

------
https://chatgpt.com/codex/tasks/task_e_68f908889a988333a7c88ea9d3d8090c