### PR TITLE
Adjust list view for streaming playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Audio Player project will be documented in this file.
 
 ### Fixed
 - prevent null user context from breaking cover retrieval
+- fix streaming playlists showing empty columns in list view
 
 ## 3.6.0 - 2025-10-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 All notable changes to the Audio Player project will be documented in this file.
 
+## 3.7.0 - 2025-10-xx
+### Changed
+- reduced playlist columns for streams
+
 ## 3.6.1 - 2025-10-24
 ### Changed
 - switched the scan dialog cache-backed polling progress updates
 
 ### Fixed
 - prevent null user context from breaking cover retrieval
-- fix streaming playlists showing empty columns in list view
 
 ## 3.6.0 - 2025-10-22
 ### Changed

--- a/css/style.css
+++ b/css/style.css
@@ -428,6 +428,17 @@ i#scanAudiosFirst {
     right: 0;
 }
 
+#playlist-container.is-stream-playlist #individual-playlist-header span.header-title {
+    min-width: calc(100% - 52px);
+    width: calc(100% - 52px);
+}
+
+#playlist-container.is-stream-playlist #individual-playlist-header span.header-artist,
+#playlist-container.is-stream-playlist #individual-playlist-header span.header-album,
+#playlist-container.is-stream-playlist #individual-playlist-header span.header-time {
+    display: none;
+}
+
 .albumwrapper li .actionsSong {
     position: relative;
     float: left;
@@ -482,6 +493,10 @@ i#scanAudiosFirst {
     overflow: hidden;
 }
 
+#playlist-container.is-stream-playlist #individual-playlist li span.title {
+    width: calc(100% - 52px);
+}
+
 #individual-playlist li span.interpret {
     position: relative;
     float: left;
@@ -491,6 +506,12 @@ i#scanAudiosFirst {
     text-overflow: ellipsis;
     overflow: hidden;
     color: var(--color-text-lighter);
+}
+
+#playlist-container.is-stream-playlist #individual-playlist li span.interpret,
+#playlist-container.is-stream-playlist #individual-playlist li span.album-indi,
+#playlist-container.is-stream-playlist #individual-playlist li span.time {
+    display: none;
 }
 
 #individual-playlist li span.album-indi {

--- a/js/app.js
+++ b/js/app.js
@@ -489,7 +489,8 @@ OCA.Audioplayer.Category = {
     },
 
     buildListView: function () {
-        document.getElementById('playlist-container').style.display = 'block';
+        let playlistContainer = document.getElementById('playlist-container');
+        playlistContainer.style.display = 'block';
         document.getElementById('empty-container').style.display = 'none';
         document.getElementById('loading').style.display = 'block';
         if (document.querySelector('.coverrow')) {
@@ -507,11 +508,20 @@ OCA.Audioplayer.Category = {
         let ul = document.createElement('ul');
         ul.id = 'individual-playlist';
         ul.classList.add('albumwrapper');
-        document.getElementById('playlist-container').appendChild(ul);
+        playlistContainer.appendChild(ul);
 
         document.querySelector('.header-title').dataset.order = '';
         document.querySelector('.header-artist').dataset.order = '';
         document.querySelector('.header-album').dataset.order = '';
+
+        playlistContainer.classList.remove('is-stream-playlist');
+        if (
+            OCA.Audioplayer.Core.CategorySelectors[0] === 'Playlist' &&
+            OCA.Audioplayer.Core.CategorySelectors[1] &&
+            OCA.Audioplayer.Core.CategorySelectors[1][0] === 'S'
+        ) {
+            playlistContainer.classList.add('is-stream-playlist');
+        }
 
         return true;
     },


### PR DESCRIPTION
## Summary
- mark streaming playlists in the list view and hide artist, album, and length columns
- expand the title column when streams are shown so rows span the available width
- document the fix in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe3e7060848333a5d00701ce2047fa