### PR TITLE
Use PHP attributes for controller access annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Audio Player project will be documented in this file.
 ## 3.7.0 - 2025-10-xx
 ### Changed
 - reduced playlist columns for streams
+- migrated controller annotations to PHP attributes
 
 ## 3.6.1 - 2025-10-24
 ### Changed

--- a/lib/Controller/CategoryController.php
+++ b/lib/Controller/CategoryController.php
@@ -12,6 +12,7 @@
 namespace OCA\audioplayer\Controller;
 
 use Doctrine\DBAL\Exception;
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\InvalidPathException;
@@ -75,10 +76,10 @@ class CategoryController extends Controller
     /**
      * Get the items for the selected category
      *
-     * @NoAdminRequired
      * @param $category
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function getCategoryItems($category)
     {
         $items = $this->categoryService->getCategoryItems($category);
@@ -91,11 +92,11 @@ class CategoryController extends Controller
     /**
      * Get the covers for the "Album Covers" view
      *
-     * @NoAdminRequired
      * @param $category
      * @param $categoryId
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function getCategoryItemCovers($category, $categoryId)
     {
         $items = $this->categoryService->getCategoryItemCovers($category, $categoryId);
@@ -119,16 +120,16 @@ class CategoryController extends Controller
         return $this->categoryService->getTrackCount($category, $categoryId);
     }
 
-        /**
+    /**
      * get the tracks for a selected category or album
      *
-     * @NoAdminRequired
      * @param string $category
      * @param string $categoryId
      * @return JSONResponse
      * @throws InvalidPathException
      * @throws NotFoundException
      */
+    #[NoAdminRequired]
     public function getTracks($category, $categoryId)
     {
         if ($categoryId[0] === 'S') $category = 'Stream';

--- a/lib/Controller/CoverController.php
+++ b/lib/Controller/CoverController.php
@@ -14,6 +14,8 @@
 namespace OCA\audioplayer\Controller;
 
 use OCA\audioplayer\Service\CoverService;
+use OCP\AppFramework\Attributes\NoAdminRequired;
+use OCP\AppFramework\Attributes\NoCSRFRequired;
 use OCP\AppFramework\Controller;
 use OCP\IRequest;
 use OCA\audioplayer\Http\ImageResponse;
@@ -32,11 +34,11 @@ class CoverController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
      * @param int $album
      * @return ImageResponse
      */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function getCover(int $album)
     {
         $cover = $this->coverService->getCover($album);

--- a/lib/Controller/DbController.php
+++ b/lib/Controller/DbController.php
@@ -2,6 +2,7 @@
 namespace OCA\audioplayer\Controller;
 
 use OCA\audioplayer\Db\DbMapper;
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -16,9 +17,7 @@ class DbController extends Controller
         $this->mapper = $mapper;
     }
 
-    /**
-     * @NoAdminRequired
-     */
+    #[NoAdminRequired]
     public function resetMediaLibrary(): JSONResponse
     {
         $this->mapper->resetMediaLibrary();

--- a/lib/Controller/MusicController.php
+++ b/lib/Controller/MusicController.php
@@ -13,6 +13,9 @@
 
 namespace OCA\audioplayer\Controller;
 
+use OCP\AppFramework\Attributes\NoAdminRequired;
+use OCP\AppFramework\Attributes\NoCSRFRequired;
+use OCP\AppFramework\Attributes\PublicPage;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -32,13 +35,13 @@ class MusicController extends Controller
     }
 
     /**
-     * @PublicPage
-     * @NoCSRFRequired
      * @param $token
      * @return JSONResponse
      * @throws \OCP\Files\NotFoundException
      * @throws \OCP\Share\Exceptions\ShareNotFound
      */
+    #[PublicPage]
+    #[NoCSRFRequired]
     public function getPublicAudioInfo($token)
     {
         if (empty($token)) {
@@ -57,12 +60,12 @@ class MusicController extends Controller
 
     /**
      * Stream files in OCP withing link-shared folder
-     * @PublicPage
-     * @NoCSRFRequired
      * @param $token
      * @param $file
      * @throws \OCP\Files\NotFoundException
      */
+    #[PublicPage]
+    #[NoCSRFRequired]
     public function getPublicAudioStream($token, $file)
     {
         if (empty($token)) {
@@ -75,11 +78,11 @@ class MusicController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
      * @param $file
      * @param $t
      */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function getAudioStream($file, $t)
     {
         $stream = $this->service->createAudioStream($file, $t);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -14,6 +14,8 @@
 namespace OCA\audioplayer\Controller;
 
 use OCA\audioplayer\Event\LoadAdditionalScriptsEvent;
+use OCP\AppFramework\Attributes\NoAdminRequired;
+use OCP\AppFramework\Attributes\NoCSRFRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
@@ -53,10 +55,10 @@ class PageController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     * @NoCSRFRequired
      * @throws \OCP\PreConditionNotMetException
      */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
     public function index()
     {
 

--- a/lib/Controller/PlaylistController.php
+++ b/lib/Controller/PlaylistController.php
@@ -13,6 +13,7 @@
 
 namespace OCA\audioplayer\Controller;
 
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -47,10 +48,10 @@ class PlaylistController extends Controller
     }
 
     /**
-     * @NoAdminRequired
      * @param $playlist
      * @return null|JSONResponse
      */
+    #[NoAdminRequired]
     public function addPlaylist($playlist)
     {
         if ($playlist !== '') {
@@ -74,12 +75,11 @@ class PlaylistController extends Controller
 
 
     /**
-     * @NoAdminRequired
-     *
      * @param integer $plId
      * @param string $newname
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function updatePlaylist($plId, $newname)
     {
 
@@ -98,23 +98,23 @@ class PlaylistController extends Controller
 
 
     /**
-     * @NoAdminRequired
      * @param $playlistid
      * @param $songid
      * @param $sorting
      * @return bool
      */
+    #[NoAdminRequired]
     public function addTrackToPlaylist($playlistid, $songid, $sorting)
     {
         return $this->service->addTrackToPlaylist((int)$playlistid, (int)$songid, (int)$sorting);
     }
 
     /**
-     * @NoAdminRequired
      * @param $playlistid
      * @param $songids
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function sortPlaylist($playlistid, $songids)
     {
         $iTrackIds = explode(';', $songids);
@@ -127,21 +127,21 @@ class PlaylistController extends Controller
     }
 
     /**
-     * @NoAdminRequired
      * @param $playlistid
      * @param $trackid
      * @return bool
      */
+    #[NoAdminRequired]
     public function removeTrackFromPlaylist($playlistid, $trackid)
     {
         return $this->service->removeTrackFromPlaylist((int)$playlistid, (int)$trackid);
     }
 
     /**
-     * @NoAdminRequired
      * @param $playlistid
      * @return bool|JSONResponse
      */
+    #[NoAdminRequired]
     public function removePlaylist($playlistid)
     {
         if (!$this->service->removePlaylist((int)$playlistid)) {

--- a/lib/Controller/ScannerController.php
+++ b/lib/Controller/ScannerController.php
@@ -20,6 +20,7 @@ use getID3;
 use getid3_exception;
 use getid3_lib;
 use OC;
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\InvalidPathException;
@@ -105,8 +106,6 @@ class ScannerController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     *
      * @param $userId
      * @param $output
      * @param $scanstop
@@ -114,6 +113,7 @@ class ScannerController extends Controller
      * @throws NotFoundException
      * @throws getid3_exception
      */
+    #[NoAdminRequired]
     public function scanForAudios($userId = null, $output = null, $scanstop = null)
     {
         set_time_limit(0);
@@ -521,9 +521,7 @@ class ScannerController extends Controller
         }
     }
 
-    /**
-     * @NoAdminRequired
-     */
+    #[NoAdminRequired]
     public function getScanProgress($scanToken)
     {
         $data = $this->readProgressCache($scanToken);
@@ -946,10 +944,9 @@ class ScannerController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     *
      * @throws NotFoundException
      */
+    #[NoAdminRequired]
     public function checkNewTracks()
     {
         // get only the relevant audio files

--- a/lib/Controller/SettingController.php
+++ b/lib/Controller/SettingController.php
@@ -11,6 +11,7 @@
 
 namespace OCA\audioplayer\Controller;
 
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -38,22 +39,22 @@ class SettingController extends Controller {
     }
 
     /**
-     * @NoAdminRequired
      * @param $type
      * @param $value
      * @return JSONResponse
      * @throws \OCP\PreConditionNotMetException
      */
+    #[NoAdminRequired]
     public function setValue($type, $value) {
         $this->settingService->setValue($this->userId, $type, $value);
         return new JSONResponse(['success' => 'true']);
     }
 
     /**
-     * @NoAdminRequired
      * @param $type
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function getValue($type) {
         $value = $this->settingService->getValue($this->userId, $type);
 
@@ -74,33 +75,33 @@ class SettingController extends Controller {
     }
 
     /**
-     * @NoAdminRequired
      * @param $value
      * @return JSONResponse
      * @throws \OCP\PreConditionNotMetException
      */
+    #[NoAdminRequired]
     public function userPath($value) {
         $success = $this->settingService->userPath($this->userId, $value);
         return new JSONResponse(['success' => $success]);
     }
 
     /**
-     * @NoAdminRequired
      * @param $trackid
      * @param $isFavorite
      * @return bool
      */
+    #[NoAdminRequired]
     public function setFavorite($trackid, $isFavorite)
     {
         return $this->settingService->setFavorite($this->userId, $trackid, $isFavorite);
     }
 
     /**
-     * @NoAdminRequired
      * @param $track_id
      * @return int|string
      * @throws \Exception
      */
+    #[NoAdminRequired]
     public function setStatistics($track_id) {
         return $this->settingService->setStatistics($this->userId, $track_id);
     }

--- a/lib/Controller/SidebarController.php
+++ b/lib/Controller/SidebarController.php
@@ -11,6 +11,7 @@
 
 namespace OCA\audioplayer\Controller;
 
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -39,10 +40,10 @@ class SidebarController extends Controller
     }
 
     /**
-     * @NoAdminRequired
      * @param $trackid
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function getAudioInfo($trackid)
     {
 
@@ -63,10 +64,10 @@ class SidebarController extends Controller
     }
 
     /**
-     * @NoAdminRequired
      * @param $trackid
      * @return JSONResponse
      */
+    #[NoAdminRequired]
     public function getPlaylists($trackid)
     {
         $playlists = $this->service->getPlaylists((int)$trackid);

--- a/lib/Controller/WhatsNewController.php
+++ b/lib/Controller/WhatsNewController.php
@@ -14,6 +14,7 @@
 namespace OCA\audioplayer\Controller;
 
 use OCA\audioplayer\WhatsNew\WhatsNewCheck;
+use OCP\AppFramework\Attributes\NoAdminRequired;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
@@ -57,9 +58,7 @@ class WhatsNewController extends Controller
         $this->logger = $logger;
     }
 
-    /**
-     * @NoAdminRequired
-     */
+    #[NoAdminRequired]
     public function get(): DataResponse
     {
         $user = $this->userSession->getUser();
@@ -97,13 +96,12 @@ class WhatsNewController extends Controller
     }
 
     /**
-     * @NoAdminRequired
-     *
      * @param string $version
      * @return DataResponse
      * @throws DoesNotExistException
      * @throws \OCP\PreConditionNotMetException
      */
+    #[NoAdminRequired]
     public function dismiss($version)
     {
         $user = $this->userSession->getUser();


### PR DESCRIPTION
## Summary
- replace legacy controller annotations with the new PHP attributes across the app
- import the relevant attribute classes for every controller
- document the migration in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe459e0adc8333a786b11aa766aa39