### PR TITLE
Hide playlist info when browsing current category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Audio Player project will be documented in this file.
 
 ### Fixed
 - Could not resolve OCA\audioplayer\DB\DbMapper #651
+- hide playlist info when browsing within the selected category
 
 
 ## 3.6.1 - 2025-10-24

--- a/js/app.js
+++ b/js/app.js
@@ -502,7 +502,7 @@ OCA.Audioplayer.Category = {
         if (document.getElementById('individual-playlist')) {
             document.getElementById('individual-playlist').remove();
         }
-        document.getElementById('individual-playlist-info').style.display = 'block';
+        document.getElementById('individual-playlist-info').style.display = 'none';
         document.getElementById('individual-playlist-header').style.display = 'block';
 
         let ul = document.createElement('ul');
@@ -578,11 +578,31 @@ OCA.Audioplayer.Category = {
             }
         });
         let category_title = document.querySelector('#myCategory .active') ? document.querySelector('#myCategory .active').firstChild['title'] : false;
-        if (category !== 'Title') {
-            document.getElementById('individual-playlist-info').innerHTML = t('audioplayer', 'Selected') + ' ' + category + ': ' + category_title;
-        } else {
-            document.getElementById('individual-playlist-info').innerHTML = t('audioplayer', 'Selected') + ': ' + category_title;
+
+        OCA.Audioplayer.Category.updatePlaylistInfo(category, category_title);
+    },
+
+    updatePlaylistInfo: function (category, categoryTitle) {
+        let info = document.getElementById('individual-playlist-info');
+        if (!info) {
+            return;
         }
+
+        if (!categoryTitle) {
+            info.style.display = 'none';
+            return;
+        }
+
+        if (category !== 'Title') {
+            info.innerHTML = t('audioplayer', 'Selected') + ' ' + category + ': ' + categoryTitle;
+        } else {
+            info.innerHTML = t('audioplayer', 'Selected') + ': ' + categoryTitle;
+        }
+
+        let selector = document.getElementById('category_selector');
+        let isSameCategory = selector && selector.value === category;
+
+        info.style.display = isSameCategory ? 'none' : 'block';
     },
 
 };


### PR DESCRIPTION
## Summary
- hide the playlist info banner when browsing within the selected category
- centralize playlist info rendering to toggle visibility based on the active category
- update the changelog entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923eea9e6d88333bb5697baba555842)